### PR TITLE
chore: fix lint violations in local repro scripts

### DIFF
--- a/check_daemon_config.py
+++ b/check_daemon_config.py
@@ -1,22 +1,22 @@
 
 import requests
-import json
-import os
+
 
 def check_daemon_info():
     try:
         response = requests.get("http://localhost:11435/api/info", timeout=5)
         response.raise_for_status()
         data = response.json()
-        
         env = data.get("env", {})
-        print(f"Daemon TOLLAMA_FORECAST_TIMEOUT_SECONDS: {env.get('TOLLAMA_FORECAST_TIMEOUT_SECONDS')}")
-        
-        # Also check if we can infer the default from code (not directly possible via API unless exposed)
-        # But we can check if the env var was picked up.
-        
+        timeout = env.get("TOLLAMA_FORECAST_TIMEOUT_SECONDS")
+        print(f"Daemon TOLLAMA_FORECAST_TIMEOUT_SECONDS: {timeout}")
+
+        # Also check whether we can infer the default from code.
+        # We can still verify whether the env var was picked up.
+
     except Exception as e:
         print(f"Error checking daemon: {e}")
+
 
 if __name__ == "__main__":
     check_daemon_info()

--- a/reproduce_timeout.py
+++ b/reproduce_timeout.py
@@ -1,20 +1,22 @@
 
 import os
-import sys
 import time
-import json
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, datetime, timedelta
+
 from fastapi.testclient import TestClient
+
 from tollama.daemon.app import create_app
+
 
 def main():
     print("Starting reproduction script...")
     start_time = time.time()
 
     # Set up environment
-    os.environ["TOLLAMA_FORECAST_TIMEOUT_SECONDS"] = "300" # Increase timeout for reproduction script to see how long it actually takes
+    # Increase timeout for reproduction script to observe the full runtime.
+    os.environ["TOLLAMA_FORECAST_TIMEOUT_SECONDS"] = "300"
 
-    print(f"Creating app...")
+    print("Creating app...")
     app = create_app()
     client = TestClient(app)
 
@@ -41,7 +43,7 @@ def main():
                 "freq": "H",
                 "timestamps": [
                     (start + timedelta(hours=i)).isoformat()
-                    for i in range(168) # 1 week of history
+                    for i in range(168)  # 1 week of history
                 ],
                 "target": [float(i) for i in range(168)],
             }
@@ -49,7 +51,7 @@ def main():
     }
 
     # Run forecast
-    print(f"Running forecast...")
+    print("Running forecast...")
     forecast_start = time.time()
     try:
         response = client.post("/v1/forecast", json=payload)
@@ -69,6 +71,7 @@ def main():
 
     total_time = time.time() - start_time
     print(f"Total execution time: {total_time:.2f}s")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Motivation

- Ensure repository lint gates pass by cleaning up small local troubleshooting scripts that caused Ruff failures. 

### Description

- Cleaned up `check_daemon_config.py` by removing unused imports, simplifying env lookup, and fixing comment/line-length issues. 
- Tidied `reproduce_timeout.py` by removing unused imports, normalizing import ordering, removing no-op f-strings, and clarifying a timeout comment. 
- Reformatted `reproduce_timeout_isolated.py` to organize imports, fix long/list formatting, add trailing commas, and remove an unused import. 

### Testing

- Ran `ruff check .` and confirmed all lint checks now pass. 
- Attempted `python -m pip install -e '.[dev]'` which failed in this environment due to an external proxy/index problem and is unrelated to these lint-only changes. 
- Ran `pytest -q` (without editable install) which failed collection due to the package not being installed in this environment (`ModuleNotFoundError: tollama`). 
- Ran `PYTHONPATH=src pytest -q` to exercise tests in-source and observed existing functional failures unrelated to the lint fixes, notably CLI stdout expectations, runner command override routing (503 vs expected 200), and console-script registration checks; these failures should be investigated separately before public release.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69957e521644832395cefe845b9c8153)