### PR TITLE
docs: add public release licensing/compliance checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ which tollama-runner-uni2ts
 
 For a full setup/run walkthrough with dependency breakdown and commands to install every TSFM model in the registry, see `docs/how-to-run.md`.
 
+Before publishing a public release, follow `docs/public-release-checklist.md` for licensing/compliance and release-readiness gates.
+
 ## Daemon Base URL and Host Config
 
 - Default CLI base URL is `http://localhost:11435`.

--- a/docs/public-release-checklist.md
+++ b/docs/public-release-checklist.md
@@ -1,0 +1,91 @@
+# Public Release Checklist
+
+This checklist is focused on **open-source publication readiness** for `tollama`,
+with extra attention on licensing and redistributability.
+
+## 1) Repository baseline
+
+- Confirm root package metadata is aligned:
+  - `pyproject.toml` project license points to `LICENSE`.
+  - root `LICENSE` file is present and accurate.
+- Confirm docs and status trackers are in sync:
+  - `README.md`
+  - `docs/covariates.md`
+  - `roadmap.md`
+  - `todo-list.md`
+
+## 2) License / compliance gate (required)
+
+### 2.1 Registry model license verification
+
+Run the optional upstream validation test with network access:
+
+```bash
+TOLLAMA_VALIDATE_REGISTRY_REMOTE=1 PYTHONPATH=src pytest -q tests/test_registry_upstream.py
+```
+
+This checks each Hugging Face registry entry against upstream metadata and flags
+license mismatches.
+
+### 2.2 High-risk model entry review
+
+Current registry includes `moirai-2.0-R-small` with `cc-by-nc-4.0`
+(`needs_acceptance: true`). This is **non-commercial** and can conflict with
+commercial/public distribution goals.
+
+Before public release, decide and document one policy:
+
+1. Keep entry, but clearly mark it as non-commercial/research-only in release notes.
+2. Move it to an optional "restricted" registry variant.
+3. Remove it from the default public registry.
+
+### 2.3 Third-party Python dependency license inventory
+
+Generate a dependency license report in a clean environment:
+
+```bash
+python -m pip install pip-licenses
+python -m pip install -e ".[dev]"
+pip-licenses --format=markdown --with-authors --with-license-file > THIRD_PARTY_LICENSES.md
+```
+
+If publishing wheels/containers, keep this artifact in the release bundle.
+
+### 2.4 Source provenance checks for non-PyPI pins
+
+`runner_timesfm` currently uses a Git commit pin (`timesfm[torch] @ git+...`).
+Before release:
+
+- Verify upstream license at that exact commit.
+- Capture commit hash + license in your release notes or NOTICE file.
+- Re-test lock/pin reproducibility in CI.
+
+## 3) Technical quality gate
+
+Run baseline checks:
+
+```bash
+ruff check .
+PYTHONPATH=src pytest -q
+```
+
+For optional runner families, run focused tests with corresponding extras
+installed.
+
+## 4) Operational and UX gate
+
+- Validate `tollama info --remote` on a fresh machine.
+- Validate auto-bootstrap runtime flow from a clean `TOLLAMA_HOME`.
+- Confirm `/api/info` redaction and capability visibility are stable.
+- Smoke test pull/list/show/run/ps/rm lifecycle end-to-end.
+
+## 5) Release decision record
+
+Before tagging public release, record:
+
+- commit SHA
+- checks run + outcomes
+- known limitations/skips
+- explicit licensing decision for restricted-license models
+
+A short markdown file under `docs/releases/` is sufficient.

--- a/roadmap.md
+++ b/roadmap.md
@@ -264,6 +264,7 @@ tollama/
 - API/model install paths enforce acceptance and return `409` when required acceptance is missing.
 - Manifest records acceptance state.
 - CLI supports `--accept-license` on pull/install paths.
+- Public-release checklist now documents license/compliance gates, including upstream registry license validation and third-party inventory generation (`docs/public-release-checklist.md`).
 
 ### Planned work / TODO
 - Record dedicated license receipts under `~/.tollama/licenses/<model>.json`.

--- a/todo-list.md
+++ b/todo-list.md
@@ -143,6 +143,10 @@
 - [x] (P1) covariates strict/best_effort 정책 모델별 표준화 (warning 템플릿 포함)
 - [ ] (P1) `tollama doctor` 설계
   - `pull/runner start/GPU/offline/forecast smoke test` 시나리오 확정
+- [~] (P0) 공개 릴리스 라이선스/컴플라이언스 체크리스트 운영
+  - 현재: `docs/public-release-checklist.md` 추가(업스트림 라이선스 검증/서드파티 라이선스 인벤토리/제한 라이선스 정책)
+  - TODO: 릴리스 태그마다 체크 결과(`docs/releases/`)를 남기고, `cc-by-nc-4.0` 모델 공개 정책을 최종 확정
+
 - [x] (P1) 6개 모델 e2e 통합 테스트 매트릭스 재검증 + 문서 동기화
   - 기준 일자: `2026-02-17`
   - pass: `chronos2`, `granite-ttm-r2`, `timesfm-2.5-200m`,


### PR DESCRIPTION
### Motivation
- Provide a short, repeatable pre-publication gate to surface licensing/compliance risks (notably the `cc-by-nc-4.0` `moirai-2.0-R-small` entry and a git-pinned `timesfm` dependency) and document steps to verify upstream provenance and third-party license inventory before making the repository public.

### Description
- Add `docs/public-release-checklist.md` with concrete checks for registry license validation, restricted-license policy, dependency license inventory, and provenance for git-pinned deps, and link the checklist from `README.md` while synchronizing `roadmap.md` and `todo-list.md` to reference the new release-readiness workflow.

### Testing
- Ran `ruff check .` which passed; attempted `python -m pip install -e ".[dev]"` failed in this environment due to package-index/proxy errors so a full editable install could not be performed; ran `PYTHONPATH=src pytest -q tests/test_registry_upstream.py` (the upstream validation test is opt-in and runs/skips as expected) and `PYTHONPATH=src pytest -q tests/test_schemas.py tests/test_registry_storage.py tests/test_cli_info.py` which showed one failing test (`test_cli_info`) in this environment, and note that a complete `pytest -q` run was not possible here because the package could not be installed into the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995868234b483239207336d63750d4f)