### PR TITLE
CLI: print errors to stdout, add --stream flag, tighten Uni2TS warning

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -447,6 +447,7 @@ def test_run_help_mentions_input_and_stream_flags() -> None:
     result = runner.invoke(app, ["run", "--help"])
     assert result.exit_code == 0
     assert "--input" in result.stdout
+    assert "--stream" in result.stdout
     assert "--no-stream" in result.stdout
     assert "stdin" in result.stdout
 


### PR DESCRIPTION
### Motivation
- Make CLI behavior match test contract by ensuring user-facing error messages are printed to `stdout` (so `CliRunner.invoke(...).stdout` contains them) and by exposing the expected `--stream` help token. 
- Surface Python 3.12+ Uni2TS/Moirai compatibility guidance reliably when a relevant model is requested.

### Description
- Add `_exit_with_message(message: str, *, code: int = 2)` which `typer.echo`s the `message` to `stdout` and raises `typer.Exit` to centralize stdout-first error exits and replace `typer.BadParameter`/exceptions in CLI flows. (`src/tollama/cli/main.py`)
- Replace CLI `--no-stream`-only behavior with an explicit toggle `--stream/--no-stream` option and wire the `stream` variable through pull/forecast paths so help shows both `--stream` and `--no-stream`. (`src/tollama/cli/main.py`)
- Route failing `info --remote` daemon errors, unsupported config key errors, missing payload, and JSON parsing/object validation failures through `_exit_with_message` so messages appear on `stdout`. (`src/tollama/cli/main.py`)
- Tighten Uni2TS/Moirai runtime warning text to the exact expected phrase and emit it on Python 3.12+ when the model name contains `moirai`/`uni2ts` (with a registry-family fallback). (`src/tollama/cli/main.py`)
- Update the CLI help test to assert the presence of `--stream` in `tests/test_cli.py`.

### Testing
- Ran linter: `PYTHONPATH=src ruff check src/tollama/cli/main.py tests/test_cli.py` and it passed.
- Ran focused pytest targets: `PYTHONPATH=src pytest -q tests/test_cli.py::test_run_help_mentions_input_and_stream_flags tests/test_cli.py::test_run_warns_for_uni2ts_models_on_python_312_plus tests/test_cli.py::test_run_rejects_non_json_input tests/test_cli.py::test_run_errors_when_payload_sources_are_missing tests/test_cli_config.py::test_config_set_rejects_unknown_key tests/test_cli_info.py::test_info_command_remote_flag_errors_when_daemon_unreachable` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69959340d5f48323bc8fe334330c9add)