### PR TITLE
Normalize CLI help test assertions for ANSI-formatted output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -446,10 +447,13 @@ def test_run_help_mentions_input_and_stream_flags() -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["run", "--help"])
     assert result.exit_code == 0
-    assert "--input" in result.stdout
-    assert "--stream" in result.stdout
-    assert "--no-stream" in result.stdout
-    assert "stdin" in result.stdout
+    # Rich may inject ANSI style escapes into option tokens when color is forced,
+    # so normalize help text before checking for stable flag names.
+    normalized_stdout = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+    assert "--input" in normalized_stdout
+    assert "--stream" in normalized_stdout
+    assert "--no-stream" in normalized_stdout
+    assert "stdin" in normalized_stdout
 
 
 def test_run_warns_for_uni2ts_models_on_python_312_plus(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Make the `run --help` test resilient to ANSI/color escapes injected by Rich so option tokens like `--input` are reliably found in help output.

### Description
- Strip ANSI escape sequences from `result.stdout` in `tests/test_cli.py::test_run_help_mentions_input_and_stream_flags` and add an `import re` so assertions check a normalized help string (file modified: `tests/test_cli.py`).

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_cli.py::test_run_help_mentions_input_and_stream_flags` and it passed.
- Ran `PYTHONPATH=src pytest -q tests/test_cli.py` and it passed.
- Ran `PYTHONPATH=src ruff check tests/test_cli.py` and linting passed.
- Note: running the full test suite with `PYTHONPATH=src pytest -q` still fails in this environment for unrelated entrypoint/packaging tests, but those failures are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69959b9bcc08832394b41808733e02ef)