### PR TITLE
feat(tide): phase-3 probabilistic output with quantile fallback (fixes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - E2E verification checklist (`docs/lag-llama-patchtst-e2e-checklist.md`)
   - helper script for targeted checks (`scripts/e2e_lag_llama_patchtst_check.sh`)
   - runner regression coverage for payload validation and validation-before-dependency-gating behavior
+- TiDE phase-3 runner path:
+  - stdio JSON-RPC inference runner with adapter-based error handling
+  - deterministic mean forecasts with best-effort quantile extraction
+  - explicit warning-based mean-only fallback when quantile outputs are unavailable
+  - regression tests for quantile success/fallback and runner wiring

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ AI agents can **invoke TSFMs as tools the moment they need a forecast.**
 | Toto Open Base 1.0 | Datadog | Past only |
 | Lag-Llama | TSFM Community | Target only |
 | PatchTST (Phase-2 baseline) | IBM Granite | Target-only point forecast (quantiles optional) |
-| TiDE (Phase-1 placeholder) | Unit8 | Planned covariate-aware runner (gated placeholder) |
+| TiDE (Phase-3 probabilistic) | Unit8 | Deterministic forecasts with best-effort quantile output + explicit mean-only fallback |
 
 ## Overview Architecture
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -366,3 +366,26 @@ tollama pull patchtst
 # run forecast
 tollama run patchtst --input examples/request.json --no-stream
 ```
+
+## TiDE Forecasting (Phase-3 probabilistic)
+
+TiDE is integrated for inference via the dedicated `tide` runner family.
+
+- model name: `tide`
+- runner family: `tide`
+- install extra: `runner_tide`
+- current runtime behavior:
+  - returns `DEPENDENCY_MISSING` when optional dependencies are absent
+  - returns deterministic mean forecasts for valid requests
+  - attempts to produce requested quantiles using probabilistic sampling
+  - explicitly falls back to mean-only responses (with warning) when quantiles are unavailable in the active runtime/backend
+
+Runtime tuning knobs (TiDE):
+
+- request `options.quantile_samples` (default: `200`) — number of probabilistic samples used for quantile estimation when quantiles are requested
+
+Calibration & limitations guidance:
+
+- quantile quality depends on runtime sampling behavior and underlying TiDE checkpoint calibration; treat intervals as best-effort uncertainty estimates, not guaranteed calibrated prediction intervals.
+- if you need tighter/steadier quantile estimates, increase `options.quantile_samples` (at the cost of latency/compute).
+- if runtime/model combination does not expose quantile extraction, response warnings will state that quantiles were omitted and mean-only output was returned.

--- a/model-registry/registry.yaml
+++ b/model-registry/registry.yaml
@@ -197,11 +197,11 @@ models:
       needs_acceptance: false
     metadata:
       implementation: tide
-      status: phase1_placeholder
-      support_level: planned
+      status: phase3_probabilistic
+      support_level: baseline
       install_extra: runner_tide
       install_command: python -m pip install -e ".[dev,runner_tide]"
-      notes: TiDE integration is scaffolded in phase-1 only. Runner validates requests and returns actionable DEPENDENCY_MISSING or NOT_IMPLEMENTED responses until inference support lands.
+      notes: TiDE runner supports deterministic forecasts and best-effort requested quantiles when runtime probabilistic outputs are available. When quantiles cannot be produced, responses explicitly fall back to mean-only forecasts with warnings.
     capabilities:
       past_covariates_numeric: true
       past_covariates_categorical: false

--- a/src/tollama/runners/tide_runner/__init__.py
+++ b/src/tollama/runners/tide_runner/__init__.py
@@ -1,1 +1,1 @@
-"""TiDE runner family package (phase-1 placeholder)."""
+"""TiDE runner family package."""

--- a/src/tollama/runners/tide_runner/adapter.py
+++ b/src/tollama/runners/tide_runner/adapter.py
@@ -1,0 +1,324 @@
+"""TiDE forecasting adapter used by the tide runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from tollama.core.schemas import ForecastRequest, ForecastResponse, SeriesForecast, SeriesInput
+
+from .errors import AdapterInputError, DependencyMissingError, UnsupportedModelError
+
+_TIDE_MODELS: dict[str, dict[str, Any]] = {
+    "tide": {
+        "repo_id": "unit8co/tide",
+        "revision": "main",
+        "implementation": "tide",
+    },
+}
+_DEFAULT_QUANTILE_SAMPLES = 200
+
+
+@dataclass(frozen=True)
+class _Dependencies:
+    np: Any
+    pd: Any
+    time_series_cls: Any
+    tide_model_cls: Any
+
+
+@dataclass(frozen=True)
+class _RuntimeConfig:
+    model_name: str
+    repo_id: str
+    revision: str
+    implementation: str
+
+
+class TideAdapter:
+    def __init__(self) -> None:
+        self._dependencies: _Dependencies | None = None
+        self._model_cache: dict[tuple[str, str, str], Any] = {}
+
+    def unload(self, model_name: str | None = None) -> None:
+        if model_name is None:
+            self._model_cache.clear()
+            return
+        self._model_cache = {key: value for key, value in self._model_cache.items() if key[0] != model_name}
+
+    def forecast(
+        self,
+        request: ForecastRequest,
+        *,
+        model_local_dir: str | None = None,
+        model_source: dict[str, Any] | None = None,
+        model_metadata: dict[str, Any] | None = None,
+    ) -> ForecastResponse:
+        runtime = _resolve_runtime_config(
+            model_name=request.model,
+            model_source=model_source,
+            model_metadata=model_metadata,
+        )
+        deps = self._resolve_dependencies()
+        model = self._get_or_load_model(runtime=runtime, model_local_dir=model_local_dir)
+
+        quantile_samples = _resolve_quantile_samples(request.options.get("quantile_samples"))
+        forecasts: list[SeriesForecast] = []
+        warnings: list[str] = []
+        quantile_fallback = False
+
+        for series in request.series:
+            target_series = _build_target_series(series=series, pd_module=deps.pd, ts_cls=deps.time_series_cls)
+            mean, quantiles = _forecast_one_series(
+                model=model,
+                target_series=target_series,
+                horizon=request.horizon,
+                requested_quantiles=list(request.quantiles),
+                quantile_samples=quantile_samples,
+            )
+            if request.quantiles and quantiles is None:
+                quantile_fallback = True
+
+            forecasts.append(
+                SeriesForecast(
+                    id=series.id,
+                    freq=series.freq,
+                    start_timestamp=_future_start_timestamp(series=series, horizon=request.horizon, pd_module=deps.pd),
+                    mean=mean,
+                    quantiles=quantiles,
+                ),
+            )
+
+        if quantile_fallback:
+            warnings.append(
+                "TiDE runtime did not expose quantile outputs for requested levels; returning mean forecasts only",
+            )
+
+        return ForecastResponse(
+            model=request.model,
+            forecasts=forecasts,
+            usage={
+                "runner": "tollama-tide",
+                "implementation": runtime.implementation,
+                "series_count": len(forecasts),
+                "horizon": request.horizon,
+                "quantile_samples": quantile_samples,
+            },
+            warnings=warnings or None,
+        )
+
+    def _get_or_load_model(self, *, runtime: _RuntimeConfig, model_local_dir: str | None) -> Any:
+        deps = self._resolve_dependencies()
+        model_ref = _existing_local_model_path(model_local_dir) or runtime.repo_id
+        key = (runtime.model_name, model_ref, runtime.revision)
+        cached = self._model_cache.get(key)
+        if cached is not None:
+            return cached
+
+        kwargs = {"model_name": model_ref}
+        try:
+            model = deps.tide_model_cls.load(**kwargs)
+        except Exception:
+            try:
+                model = deps.tide_model_cls.from_pretrained(model_ref)
+            except Exception as exc:  # noqa: BLE001
+                raise AdapterInputError(f"failed to load TiDE model {model_ref!r}: {exc}") from exc
+
+        self._model_cache[key] = model
+        return model
+
+    def _resolve_dependencies(self) -> _Dependencies:
+        if self._dependencies is not None:
+            return self._dependencies
+
+        missing: list[str] = []
+        try:
+            import numpy as np
+        except ModuleNotFoundError as exc:
+            missing.append(exc.name or "numpy")
+            np = None
+
+        try:
+            import pandas as pd
+        except ModuleNotFoundError as exc:
+            missing.append(exc.name or "pandas")
+            pd = None
+
+        time_series_cls = None
+        tide_model_cls = None
+        try:
+            from darts import TimeSeries
+            from darts.models import TiDEModel
+
+            time_series_cls = TimeSeries
+            tide_model_cls = TiDEModel
+        except ModuleNotFoundError as exc:
+            missing.append(exc.name or "darts")
+
+        if missing or time_series_cls is None or tide_model_cls is None or np is None or pd is None:
+            joined = ", ".join(sorted(set(missing or ["darts"])))
+            raise DependencyMissingError(
+                "missing optional tide runner dependencies "
+                f"({joined}); install them with `pip install -e \".[dev,runner_tide]\"`",
+            )
+
+        deps = _Dependencies(np=np, pd=pd, time_series_cls=time_series_cls, tide_model_cls=tide_model_cls)
+        self._dependencies = deps
+        return deps
+
+
+def _forecast_one_series(*, model: Any, target_series: Any, horizon: int, requested_quantiles: list[float], quantile_samples: int) -> tuple[list[float], dict[str, list[float]] | None]:
+    mean_prediction = _predict(model=model, series=target_series, horizon=horizon, num_samples=1)
+    mean = _timeseries_to_vector(mean_prediction, label="mean", horizon=horizon)
+
+    if not requested_quantiles:
+        return mean, None
+
+    probabilistic_prediction = _predict(model=model, series=target_series, horizon=horizon, num_samples=quantile_samples)
+    quantiles = _extract_quantiles(probabilistic_prediction, requested_quantiles=requested_quantiles, horizon=horizon)
+    return mean, quantiles
+
+
+def _predict(*, model: Any, series: Any, horizon: int, num_samples: int) -> Any:
+    try:
+        return model.predict(n=horizon, series=series, num_samples=num_samples)
+    except TypeError:
+        return model.predict(n=horizon, num_samples=num_samples)
+    except Exception as exc:  # noqa: BLE001
+        raise AdapterInputError(f"TiDE prediction failed: {exc}") from exc
+
+
+def _extract_quantiles(prediction: Any, *, requested_quantiles: list[float], horizon: int) -> dict[str, list[float]] | None:
+    quantile_ts_fn = getattr(prediction, "quantile_timeseries", None)
+    if not callable(quantile_ts_fn):
+        return None
+
+    payload: dict[str, list[float]] = {}
+    for value in requested_quantiles:
+        q = float(value)
+        try:
+            quantile_series = quantile_ts_fn(q)
+        except Exception:
+            return None
+        payload[format(q, "g")] = _timeseries_to_vector(quantile_series, label=f"quantile {format(q, 'g')}", horizon=horizon)
+    return payload
+
+
+def _timeseries_to_vector(series: Any, *, label: str, horizon: int) -> list[float]:
+    values_fn = getattr(series, "values", None)
+    if callable(values_fn):
+        values = values_fn()
+    else:
+        values = getattr(series, "values", None)
+
+    if values is None and hasattr(series, "to_numpy"):
+        values = series.to_numpy()
+
+    if values is None:
+        raise AdapterInputError(f"TiDE {label} output is unavailable")
+
+    if hasattr(values, "tolist"):
+        values = values.tolist()
+
+    flattened: list[float] = []
+    if isinstance(values, list):
+        while values and isinstance(values[0], list):
+            values = [row[0] if isinstance(row, list) and row else row for row in values]
+        for item in values:
+            if isinstance(item, bool):
+                flattened.append(float(int(item)))
+            elif isinstance(item, (int, float)):
+                flattened.append(float(item))
+            elif hasattr(item, "item"):
+                flattened.append(float(item.item()))
+            else:
+                raise AdapterInputError(f"TiDE {label} output contains non-numeric values")
+    else:
+        raise AdapterInputError(f"TiDE {label} output has unexpected shape")
+
+    if len(flattened) < horizon:
+        raise AdapterInputError(f"TiDE {label} output is shorter than requested horizon ({len(flattened)} < {horizon})")
+    return flattened[:horizon]
+
+
+def _build_target_series(*, series: SeriesInput, pd_module: Any, ts_cls: Any) -> Any:
+    if len(series.timestamps) != len(series.target):
+        raise AdapterInputError(f"series {series.id!r} timestamps and target lengths must match")
+    if len(series.target) < 2:
+        raise AdapterInputError("each input series must include at least two target points")
+
+    try:
+        index = pd_module.to_datetime(series.timestamps, utc=True, errors="raise")
+    except Exception as exc:  # noqa: BLE001
+        raise AdapterInputError(f"invalid timestamps for series {series.id!r}: {exc}") from exc
+
+    try:
+        return ts_cls.from_times_and_values(index, [float(v) for v in series.target], freq=series.freq)
+    except Exception as exc:  # noqa: BLE001
+        raise AdapterInputError(f"failed to build TiDE target series for {series.id!r}: {exc}") from exc
+
+
+def _future_start_timestamp(*, series: SeriesInput, horizon: int, pd_module: Any) -> str:
+    try:
+        parsed = pd_module.to_datetime([series.timestamps[-1]], utc=True, errors="raise")
+        generated = pd_module.date_range(start=parsed[0], periods=horizon + 1, freq=series.freq)
+    except Exception as exc:  # noqa: BLE001
+        raise AdapterInputError(f"invalid frequency {series.freq!r} for tide forecast") from exc
+    return _to_iso_timestamp(generated[1])
+
+
+def _to_iso_timestamp(value: Any) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat()).replace("+00:00", "Z")
+    return str(value)
+
+
+def _resolve_quantile_samples(raw: Any) -> int:
+    if raw is None:
+        return _DEFAULT_QUANTILE_SAMPLES
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 1:
+        raise AdapterInputError("quantile_samples option must be an integer greater than 1")
+    return raw
+
+
+def _resolve_runtime_config(*, model_name: str, model_source: dict[str, Any] | None, model_metadata: dict[str, Any] | None) -> _RuntimeConfig:
+    defaults = _TIDE_MODELS.get(model_name, {})
+    repo_id = _dict_str(model_source, "repo_id") or _string_or_none(defaults.get("repo_id"))
+    revision = _dict_str(model_source, "revision") or _string_or_none(defaults.get("revision")) or "main"
+    implementation = _dict_str(model_metadata, "implementation") or _string_or_none(defaults.get("implementation")) or "tide"
+
+    if repo_id is None:
+        raise UnsupportedModelError(f"unsupported tide model {model_name!r}; missing repo_id")
+
+    return _RuntimeConfig(model_name=model_name, repo_id=repo_id, revision=revision, implementation=implementation)
+
+
+def _existing_local_model_path(model_local_dir: str | None) -> str | None:
+    if not model_local_dir:
+        return None
+    path = Path(model_local_dir.strip())
+    if not path.exists():
+        return None
+    return str(path)
+
+
+def _dict_str(payload: dict[str, Any] | None, key: str) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    return _string_or_none(payload.get(key))
+
+
+def _string_or_none(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    return normalized

--- a/src/tollama/runners/tide_runner/errors.py
+++ b/src/tollama/runners/tide_runner/errors.py
@@ -1,0 +1,15 @@
+"""Error types for TiDE runner adapter."""
+
+from __future__ import annotations
+
+
+class DependencyMissingError(RuntimeError):
+    """Raised when optional runner dependencies are unavailable."""
+
+
+class UnsupportedModelError(ValueError):
+    """Raised when a model cannot be mapped to this runner."""
+
+
+class AdapterInputError(ValueError):
+    """Raised when canonical request data cannot be transformed for inference."""

--- a/src/tollama/runners/tide_runner/main.py
+++ b/src/tollama/runners/tide_runner/main.py
@@ -1,9 +1,9 @@
-"""TiDE runner process over stdio JSON-RPC (phase-1 placeholder)."""
+"""TiDE runner process over stdio JSON-RPC."""
 
 from __future__ import annotations
 
-import importlib.util
 import sys
+import time
 from collections.abc import Mapping
 from typing import Any, TextIO
 
@@ -19,9 +19,13 @@ from tollama.core.protocol import (
     validate_request,
 )
 from tollama.core.schemas import ForecastRequest
+from tollama.runners.runtime_telemetry import enrich_forecast_response
+
+from .adapter import TideAdapter
+from .errors import AdapterInputError, DependencyMissingError, UnsupportedModelError
 
 RUNNER_NAME = "tollama-tide"
-RUNNER_VERSION = "0.1.0"
+RUNNER_VERSION = "0.2.0"
 UNKNOWN_REQUEST_ID = "unknown"
 CAPABILITIES = ("hello", "forecast", "unload")
 _SUPPORTED_FAMILIES = ["tide"]
@@ -50,9 +54,28 @@ def _error_response(
     )
 
 
-def _has_tide_dependencies() -> bool:
-    # TiDE lives in darts.models.forecasting.tide_model (u8darts package).
-    return importlib.util.find_spec("darts") is not None
+def _optional_nonempty_str(params: Mapping[str, Any], key: str) -> str | None:
+    value = params.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string when provided")
+    return value.strip()
+
+
+def _optional_string_key_mapping(params: Mapping[str, Any], key: str) -> dict[str, Any] | None:
+    value = params.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{key} must be an object when provided")
+
+    normalized: dict[str, Any] = {}
+    for raw_key, raw_value in value.items():
+        if not isinstance(raw_key, str):
+            raise ValueError(f"{key} keys must be strings")
+        normalized[raw_key] = raw_value
+    return normalized
 
 
 def _handle_hello(request: ProtocolRequest) -> ProtocolResponse:
@@ -63,22 +86,38 @@ def _handle_hello(request: ProtocolRequest) -> ProtocolResponse:
             "version": RUNNER_VERSION,
             "capabilities": list(CAPABILITIES),
             "supported_families": _SUPPORTED_FAMILIES,
-            "status": "phase1_placeholder",
+            "status": "phase3_probabilistic",
         },
     )
 
 
-def _handle_unload(request: ProtocolRequest) -> ProtocolResponse:
+def _handle_unload(request: ProtocolRequest, adapter: TideAdapter) -> ProtocolResponse:
+    model_name = request.params.get("model")
+    if model_name is not None and (not isinstance(model_name, str) or not model_name):
+        return _error_response(
+            request.id,
+            code=-32602,
+            message="invalid params",
+            data={"details": "model must be a non-empty string when provided"},
+        )
+    adapter.unload(model_name if isinstance(model_name, str) else None)
     return ProtocolResponse(
         id=request.id,
-        result={"unloaded": True, "model": request.params.get("model")},
+        result={"unloaded": True, "model": model_name},
     )
 
 
-def _handle_forecast(request: ProtocolRequest) -> ProtocolResponse:
+def _handle_forecast(request: ProtocolRequest, adapter: TideAdapter) -> ProtocolResponse:
     canonical_params = {
         key: value for key, value in request.params.items() if key in _FORECAST_REQUEST_FIELDS
     }
+    try:
+        model_local_dir = _optional_nonempty_str(request.params, "model_local_dir")
+        model_source = _optional_string_key_mapping(request.params, "model_source")
+        model_metadata = _optional_string_key_mapping(request.params, "model_metadata")
+    except ValueError as exc:
+        return _error_response(request.id, code="BAD_REQUEST", message=str(exc))
+
     try:
         forecast_request = ForecastRequest.model_validate(canonical_params)
     except ValidationError as exc:
@@ -89,36 +128,33 @@ def _handle_forecast(request: ProtocolRequest) -> ProtocolResponse:
             data={"details": str(exc)},
         )
 
-    if forecast_request.model != "tide":
-        return _error_response(
-            request.id,
-            code="MODEL_UNSUPPORTED",
-            message=(
-                f"TiDE placeholder runner only supports model='tide'; got {forecast_request.model!r}"
-            ),
+    try:
+        started_at = time.perf_counter()
+        response = adapter.forecast(
+            forecast_request,
+            model_local_dir=model_local_dir,
+            model_source=model_source,
+            model_metadata=model_metadata,
         )
+        inference_ms = (time.perf_counter() - started_at) * 1000.0
+    except DependencyMissingError as exc:
+        return _error_response(request.id, code="DEPENDENCY_MISSING", message=str(exc))
+    except UnsupportedModelError as exc:
+        return _error_response(request.id, code="MODEL_UNSUPPORTED", message=str(exc))
+    except AdapterInputError as exc:
+        return _error_response(request.id, code="BAD_REQUEST", message=str(exc))
+    except ValueError as exc:
+        return _error_response(request.id, code="FORECAST_ERROR", message=str(exc))
 
-    if not _has_tide_dependencies():
-        return _error_response(
-            request.id,
-            code="DEPENDENCY_MISSING",
-            message=(
-                "missing TiDE optional dependencies. Install with "
-                "`pip install -e \".[dev,runner_tide]\"` and retry"
-            ),
-        )
-
-    return _error_response(
-        request.id,
-        code="NOT_IMPLEMENTED",
-        message=(
-            "TiDE runner is currently phase-1 placeholder only; "
-            "inference support is not implemented yet."
-        ),
+    response = enrich_forecast_response(
+        response=response,
+        runner_name=RUNNER_NAME,
+        inference_ms=inference_ms,
     )
+    return ProtocolResponse(id=request.id, result=response.model_dump(mode="json", exclude_none=True))
 
 
-def handle_request_line(line: str | bytes) -> ProtocolResponse:
+def handle_request_line(line: str | bytes, adapter: TideAdapter) -> ProtocolResponse:
     payload: Mapping[str, Any] | None = None
     request_id = UNKNOWN_REQUEST_ID
 
@@ -137,9 +173,9 @@ def handle_request_line(line: str | bytes) -> ProtocolResponse:
     if request.method == "hello":
         return _handle_hello(request)
     if request.method == "forecast":
-        return _handle_forecast(request)
+        return _handle_forecast(request, adapter)
     if request.method == "unload":
-        return _handle_unload(request)
+        return _handle_unload(request, adapter)
 
     return _error_response(
         request.id,
@@ -150,10 +186,11 @@ def handle_request_line(line: str | bytes) -> ProtocolResponse:
 
 
 def serve(stdin: TextIO = sys.stdin, stdout: TextIO = sys.stdout) -> int:
+    adapter = TideAdapter()
     for line in stdin:
         if not line.strip():
             continue
-        response = handle_request_line(line)
+        response = handle_request_line(line, adapter)
         stdout.write(encode_line(response))
         stdout.flush()
     return 0

--- a/tests/test_registry_storage.py
+++ b/tests/test_registry_storage.py
@@ -144,11 +144,11 @@ def test_registry_loads_required_model_specs() -> None:
     assert tide.source.revision == "main"
     assert tide.metadata == {
         "implementation": "tide",
-        "status": "phase1_placeholder",
-        "support_level": "planned",
+        "status": "phase3_probabilistic",
+        "support_level": "baseline",
         "install_extra": "runner_tide",
         "install_command": 'python -m pip install -e ".[dev,runner_tide]"',
-        "notes": "TiDE integration is scaffolded in phase-1 only. Runner validates requests and returns actionable DEPENDENCY_MISSING or NOT_IMPLEMENTED responses until inference support lands.",
+        "notes": "TiDE runner supports deterministic forecasts and best-effort requested quantiles when runtime probabilistic outputs are available. When quantiles cannot be produced, responses explicitly fall back to mean-only forecasts with warnings.",
     }
 
     lag_llama = registry["lag-llama"]

--- a/tests/test_tide_adapter.py
+++ b/tests/test_tide_adapter.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tollama.core.schemas import ForecastRequest
+from tollama.runners.tide_runner.adapter import TideAdapter
+
+
+class _FakeDate:
+    def __init__(self, iso: str) -> None:
+        self._iso = iso
+
+    def isoformat(self) -> str:
+        return self._iso
+
+
+class _FakePandas:
+    @staticmethod
+    def to_datetime(values: list[str], utc: bool = True, errors: str = "raise") -> list[str]:
+        del utc, errors
+        return values
+
+    @staticmethod
+    def date_range(start: Any, periods: int, freq: str) -> list[_FakeDate]:
+        del start
+        if freq != "D":
+            raise ValueError("unsupported")
+        return [_FakeDate(f"2025-01-{index:02d}T00:00:00+00:00") for index in range(1, periods + 1)]
+
+
+class _FakeTimeSeries:
+    def __init__(self, values: list[float]) -> None:
+        self._values = values
+
+    @classmethod
+    def from_times_and_values(cls, times: Any, values: list[float], freq: str) -> _FakeTimeSeries:
+        del times, freq
+        return cls(values)
+
+    def values(self) -> list[list[float]]:
+        return [[value] for value in self._values]
+
+
+class _FakePrediction:
+    def __init__(self, mean: list[float], quantiles: dict[float, list[float]] | None) -> None:
+        self._mean = mean
+        self._quantiles = quantiles
+
+    def values(self) -> list[list[float]]:
+        return [[value] for value in self._mean]
+
+    def quantile_timeseries(self, quantile: float) -> _FakeTimeSeries:
+        if self._quantiles is None or quantile not in self._quantiles:
+            raise ValueError("missing")
+        return _FakeTimeSeries(self._quantiles[quantile])
+
+
+class _FakeModelWithQuantiles:
+    def predict(self, n: int, series: Any, num_samples: int) -> _FakePrediction:
+        del n, series
+        if num_samples == 1:
+            return _FakePrediction([10.0, 11.0], None)
+        return _FakePrediction([10.0, 11.0], {0.1: [9.0, 10.0], 0.9: [11.0, 12.0]})
+
+
+class _FakeModelNoQuantiles:
+    def predict(self, n: int, series: Any, num_samples: int) -> _FakePrediction:
+        del n, series, num_samples
+        return _FakePrediction([10.0, 11.0], None)
+
+
+def _request() -> ForecastRequest:
+    return ForecastRequest.model_validate(
+        {
+            "model": "tide",
+            "horizon": 2,
+            "quantiles": [0.1, 0.9],
+            "series": [
+                {
+                    "id": "s1",
+                    "freq": "D",
+                    "timestamps": ["2025-01-01", "2025-01-02", "2025-01-03"],
+                    "target": [1.0, 2.0, 3.0],
+                }
+            ],
+            "options": {},
+        },
+    )
+
+
+def _deps() -> Any:
+    return type(
+        "D",
+        (),
+        {"np": object(), "pd": _FakePandas(), "time_series_cls": _FakeTimeSeries, "tide_model_cls": object},
+    )()
+
+
+def test_tide_adapter_returns_quantiles_when_runtime_supports_probabilistic_output(monkeypatch) -> None:
+    adapter = TideAdapter()
+    monkeypatch.setattr(adapter, "_resolve_dependencies", _deps)
+    monkeypatch.setattr(adapter, "_get_or_load_model", lambda **kwargs: _FakeModelWithQuantiles())
+
+    response = adapter.forecast(_request())
+
+    assert response.forecasts[0].mean == [10.0, 11.0]
+    assert response.forecasts[0].quantiles == {"0.1": [9.0, 10.0], "0.9": [11.0, 12.0]}
+    assert response.warnings is None
+
+
+def test_tide_adapter_falls_back_to_mean_only_when_quantiles_unavailable(monkeypatch) -> None:
+    adapter = TideAdapter()
+    monkeypatch.setattr(adapter, "_resolve_dependencies", _deps)
+    monkeypatch.setattr(adapter, "_get_or_load_model", lambda **kwargs: _FakeModelNoQuantiles())
+
+    response = adapter.forecast(_request())
+
+    assert response.forecasts[0].mean == [10.0, 11.0]
+    assert response.forecasts[0].quantiles is None
+    assert response.warnings is not None
+    assert "did not expose quantile outputs" in response.warnings[0]

--- a/tests/test_tide_runner.py
+++ b/tests/test_tide_runner.py
@@ -1,9 +1,10 @@
-"""Unit tests for TiDE phase-1 placeholder runner."""
+"""Unit tests for TiDE runner process wiring."""
 
 from __future__ import annotations
 
 import json
 
+from tollama.core.schemas import ForecastResponse, SeriesForecast
 from tollama.runners.tide_runner import main as tide_main
 
 
@@ -24,30 +25,41 @@ def _valid_forecast_params() -> dict[str, object]:
     }
 
 
+class _OkAdapter:
+    def forecast(self, request, **kwargs):
+        del request, kwargs
+        return ForecastResponse(
+            model="tide",
+            forecasts=[
+                SeriesForecast(
+                    id="s1",
+                    freq="D",
+                    start_timestamp="2025-01-03T00:00:00Z",
+                    mean=[1.0, 1.0],
+                    quantiles={"0.1": [0.9, 0.9], "0.9": [1.1, 1.1]},
+                ),
+            ],
+        )
+
+    def unload(self, model_name=None):
+        del model_name
+
+
 def test_tide_runner_hello_reports_supported_family_and_status() -> None:
     response = tide_main.handle_request_line(
         json.dumps({"id": "req-1", "method": "hello", "params": {}}),
+        adapter=_OkAdapter(),
     )
     payload = response.model_dump(mode="json", exclude_none=True)
     assert payload["result"]["supported_families"] == ["tide"]
-    assert payload["result"]["status"] == "phase1_placeholder"
+    assert payload["result"]["status"] == "phase3_probabilistic"
 
 
-def test_tide_runner_forecast_returns_dependency_missing_when_darts_absent(monkeypatch) -> None:
-    monkeypatch.setattr(tide_main, "_has_tide_dependencies", lambda: False)
+def test_tide_runner_forecast_happy_path_returns_result_payload() -> None:
     response = tide_main.handle_request_line(
         json.dumps({"id": "req-2", "method": "forecast", "params": _valid_forecast_params()}),
+        adapter=_OkAdapter(),
     )
     payload = response.model_dump(mode="json", exclude_none=True)
-    assert payload["error"]["code"] == "DEPENDENCY_MISSING"
-    assert "runner_tide" in payload["error"]["message"]
-
-
-def test_tide_runner_forecast_returns_not_implemented_when_darts_present(monkeypatch) -> None:
-    monkeypatch.setattr(tide_main, "_has_tide_dependencies", lambda: True)
-    response = tide_main.handle_request_line(
-        json.dumps({"id": "req-3", "method": "forecast", "params": _valid_forecast_params()}),
-    )
-    payload = response.model_dump(mode="json", exclude_none=True)
-    assert payload["error"]["code"] == "NOT_IMPLEMENTED"
-    assert "phase-1 placeholder" in payload["error"]["message"]
+    assert payload["result"]["model"] == "tide"
+    assert payload["result"]["forecasts"][0]["quantiles"]["0.1"] == [0.9, 0.9]


### PR DESCRIPTION
## Summary\n- implement TiDE phase-3 runner with adapter-based inference path\n- add best-effort quantile extraction from probabilistic outputs\n- keep explicit fallback to mean-only forecasts with warning when quantiles are unavailable\n- add runner/adapter tests for quantile success and fallback behavior\n- update registry + docs (README/models/changelog) with calibration/limitations guidance\n\n## Validation\n- .......                                                                  [100%]
=============================== warnings summary ===============================
../../../../../opt/anaconda3/lib/python3.11/site-packages/_pytest/config/__init__.py:1373
  /opt/anaconda3/lib/python3.11/site-packages/_pytest/config/__init__.py:1373: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n\n## Notes\n- quantile outputs are runtime-dependent; fallback is intentional and surfaced via response warnings.