### PR TITLE
Add N-HiTS phase-1 baseline placeholder integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ AI agents can **invoke TSFMs as tools the moment they need a forecast.**
 ├──────┬──────┬──────┬──────┬──────┬──────┬──────────────┤
 │      │ stdio JSON-lines protocol      │              │
 │      ▼      ▼      ▼      ▼      ▼      ▼              │
-│ torch timesfm uni2ts sundial toto lag_llama patchtst tide mock │
+│ torch timesfm uni2ts sundial toto lag_llama patchtst tide nhits mock │
 │   (Chronos, Granite, Lag-Llama)                        │
 │   Independent venv per family — zero dependency clash   │
 └────────────────────────────────────────────────────────┘

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -41,6 +41,7 @@ Additional docs:
 | `sundial-base-128m` | `sundial` | `thuml/sundial-base-128m` | `main` | `apache-2.0` | No | `runner_sundial` |
 | `toto-open-base-1.0` | `toto` | `Datadog/Toto-Open-Base-1.0` | `main` | `apache-2.0` | No | `runner_toto` |
 | `patchtst` | `patchtst` | `ibm-granite/granite-timeseries-patchtst` | `main` | `apache-2.0` | No | `runner_patchtst` |
+| `nhits` | `nhits` | `cchallu/nhits-air-passengers` | `main` | `apache-2.0` | No | `runner_nhits` |
 
 > [!NOTE]
 > `timesfm` models may take several minutes to compile on the first run. The default timeout has been increased to 5 minutes to accommodate this, but slower machines may require even more time.
@@ -50,6 +51,8 @@ Toto supports target + past numeric covariates; known-future/static/categorical 
 
 > [!IMPORTANT]
 > `patchtst` is a **Phase-2 baseline integration**: it is discoverable/pullable and now executes canonical target-only forecasts via the dedicated runner family. Quantiles are returned when the backend exposes them; otherwise the runner returns mean-only forecasts with a warning. If dependencies are missing, the runner returns `DEPENDENCY_MISSING` with the install command `python -m pip install -e ".[dev,runner_patchtst]"`.
+>
+> `nhits` is currently a **Phase-1 placeholder integration**: it is discoverable/pullable and routes to a dedicated runner family, but forecast execution intentionally returns `DEPENDENCY_MISSING`/`NOT_IMPLEMENTED` with guidance until full N-HiTS inference support lands.
 
 ## Requirements
 
@@ -89,6 +92,7 @@ Optional extras:
 | `runner_sundial` | Sundial runner dependencies | `transformers`, `torch`, `numpy`, `pandas`, `huggingface_hub` |
 | `runner_toto` | Toto runner dependencies | `toto-ts`, `torch`, `numpy`, `pandas` |
 | `runner_patchtst` | PatchTST runner dependencies | `transformers` |
+| `runner_nhits` | N-HiTS runner dependencies | `neuralforecast`, `pytorch-lightning`, `torch` |
 
 ## One-Time Environment Setup (Default: Per-Family Runtime Isolation)
 
@@ -112,7 +116,7 @@ With the default `daemon.auto_bootstrap=true`, family runtimes are created lazil
 If you prefer single-environment mode (legacy), install all runner extras in the same `.venv`:
 
 ```bash
-python -m pip install -e ".[dev,runner_torch,runner_timesfm,runner_uni2ts,runner_sundial,runner_toto,runner_patchtst]"
+python -m pip install -e ".[dev,runner_torch,runner_timesfm,runner_uni2ts,runner_sundial,runner_toto,runner_patchtst,runner_nhits]"
 ```
 
 ## Single-Environment Checklist (Legacy)
@@ -134,7 +138,7 @@ Use this checklist to avoid mixed Conda/system/venv runners:
 python3.11 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip setuptools wheel
-python -m pip install -e ".[dev,runner_torch,runner_timesfm,runner_uni2ts,runner_sundial,runner_toto,runner_patchtst]"
+python -m pip install -e ".[dev,runner_torch,runner_timesfm,runner_uni2ts,runner_sundial,runner_toto,runner_patchtst,runner_nhits]"
 
 which python
 which tollama

--- a/docs/models.md
+++ b/docs/models.md
@@ -404,3 +404,22 @@ Calibration & limitations guidance:
 - quantile quality depends on runtime sampling behavior and underlying TiDE checkpoint calibration; treat intervals as best-effort uncertainty estimates, not guaranteed calibrated prediction intervals.
 - if you need tighter/steadier quantile estimates, increase `options.quantile_samples` (at the cost of latency/compute).
 - if runtime/model combination does not expose quantile extraction, response warnings will state that quantiles were omitted and mean-only output was returned.
+
+## N-HiTS Forecasting (Phase-1 placeholder)
+
+N-HiTS is registered under its own `nhits` runner family for discovery, pull/install, and routing.
+
+- model name: `nhits`
+- runner family: `nhits`
+- install extra: `runner_nhits`
+- current runtime behavior:
+  - returns `DEPENDENCY_MISSING` with install guidance when optional dependencies are absent
+  - returns `NOT_IMPLEMENTED` after dependency gating because forecast execution is intentionally disabled in phase-1
+
+```bash
+# install N-HiTS placeholder runner dependencies
+python -m pip install -e ".[dev,runner_nhits]"
+
+# pull registry entry
+tollama pull nhits
+```

--- a/model-registry/registry.yaml
+++ b/model-registry/registry.yaml
@@ -208,3 +208,26 @@ models:
       future_covariates_numeric: true
       future_covariates_categorical: false
       static_covariates: true
+
+  - name: nhits
+    family: nhits
+    source:
+      type: huggingface
+      repo_id: cchallu/nhits-air-passengers
+      revision: main
+    license:
+      type: apache-2.0
+      needs_acceptance: false
+    metadata:
+      implementation: nhits
+      status: phase1_placeholder
+      support_level: experimental
+      install_extra: runner_nhits
+      install_command: python -m pip install -e ".[dev,runner_nhits]"
+      notes: N-HiTS is registered for discovery and routing. Phase-1 runner is a capability-gated placeholder and returns explicit DEPENDENCY_MISSING or NOT_IMPLEMENTED guidance until full inference support lands.
+    capabilities:
+      past_covariates_numeric: false
+      past_covariates_categorical: false
+      future_covariates_numeric: false
+      future_covariates_categorical: false
+      static_covariates: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ tollama-runner-toto = "tollama.runners.toto_runner.main:main"
 tollama-runner-lag-llama = "tollama.runners.lag_llama_runner.main:main"
 tollama-runner-patchtst = "tollama.runners.patchtst_runner.main:main"
 tollama-runner-tide = "tollama.runners.tide_runner.main:main"
+tollama-runner-nhits = "tollama.runners.nhits_runner.main:main"
 tollama-mcp = "tollama.mcp.__main__:main"
 tollama-dashboard = "tollama.tui.app:main"
 
@@ -129,6 +130,11 @@ runner_patchtst = [
 ]
 runner_tide = [
   "u8darts>=0.30.0",
+  "torch>=2.0",
+]
+runner_nhits = [
+  "neuralforecast>=1.7.0",
+  "pytorch-lightning>=2.0,<3.0",
   "torch>=2.0",
 ]
 tui = [

--- a/src/tollama/core/runtime_bootstrap.py
+++ b/src/tollama/core/runtime_bootstrap.py
@@ -1,6 +1,6 @@
 """Per-family virtual environment bootstrap for runner dependency isolation.
 
-Each runner family (torch, timesfm, uni2ts, sundial, toto, lag_llama, patchtst, tide) can be installed
+Each runner family (torch, timesfm, uni2ts, sundial, toto, lag_llama, patchtst, tide, nhits) can be installed
 into its own virtualenv under ``~/.tollama/runtimes/<family>/venv/``.  This
 keeps heavyweight and potentially conflicting ML dependencies from interfering
 with one another.
@@ -40,6 +40,7 @@ FAMILY_EXTRAS: dict[str, str] = {
     "lag_llama": "runner-lag-llama",
     "patchtst": "runner-patchtst",
     "tide": "runner-tide",
+    "nhits": "runner-nhits",
 }
 
 # Families that require specific Python versions.
@@ -62,6 +63,7 @@ FAMILY_RUNNER_MODULES: dict[str, str] = {
     "lag_llama": "tollama.runners.lag_llama_runner.main",
     "patchtst": "tollama.runners.patchtst_runner.main",
     "tide": "tollama.runners.tide_runner.main",
+    "nhits": "tollama.runners.nhits_runner.main",
 }
 
 _STATE_FILENAME = "installed.json"

--- a/src/tollama/runners/nhits_runner/__init__.py
+++ b/src/tollama/runners/nhits_runner/__init__.py
@@ -1,0 +1,1 @@
+"""N-HiTS runner package."""

--- a/src/tollama/runners/nhits_runner/adapter.py
+++ b/src/tollama/runners/nhits_runner/adapter.py
@@ -1,0 +1,49 @@
+"""Phase-1 placeholder adapter for N-HiTS runner."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from tollama.core.schemas import ForecastRequest
+
+from .errors import DependencyMissingError, NotImplementedRunnerError
+
+_INSTALL_HINT = 'python -m pip install -e ".[dev,runner_nhits]"'
+
+
+class NhitsAdapter:
+    """Capability-gated placeholder adapter for initial N-HiTS integration."""
+
+    def unload(self, model_name: str | None = None) -> None:
+        del model_name
+
+    def forecast(
+        self,
+        request: ForecastRequest,
+        *,
+        model_local_dir: str | None = None,
+        model_source: Mapping[str, Any] | None = None,
+        model_metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        del request, model_local_dir, model_source
+
+        metadata = dict(model_metadata or {})
+        status = str(metadata.get("status") or "").strip().lower()
+        if status and status != "phase1_placeholder":
+            raise NotImplementedRunnerError(
+                "N-HiTS runner implementation is not available yet for status "
+                f"{status!r}. Track progress in tollama milestones.",
+            )
+
+        if metadata.get("dependency_probe", True):
+            raise DependencyMissingError(
+                "N-HiTS Phase-1 baseline is scaffolded but optional runtime dependencies "
+                f"are not installed yet. Install with `{_INSTALL_HINT}` and retry.",
+            )
+
+        raise NotImplementedRunnerError(
+            "N-HiTS Phase-1 baseline runner is discoverable and routable, but forecast "
+            "execution is intentionally disabled. Full inference will land in a follow-up "
+            "phase.",
+        )

--- a/src/tollama/runners/nhits_runner/errors.py
+++ b/src/tollama/runners/nhits_runner/errors.py
@@ -1,0 +1,15 @@
+"""Shared N-HiTS runner error types."""
+
+from __future__ import annotations
+
+
+class DependencyMissingError(RuntimeError):
+    """Raised when optional N-HiTS dependencies are missing."""
+
+
+class NotImplementedRunnerError(RuntimeError):
+    """Raised when placeholder paths are reached before full N-HiTS support."""
+
+
+class AdapterInputError(ValueError):
+    """Raised when request input is invalid for the N-HiTS adapter."""

--- a/src/tollama/runners/nhits_runner/main.py
+++ b/src/tollama/runners/nhits_runner/main.py
@@ -1,0 +1,196 @@
+"""N-HiTS runner process over stdio JSON-RPC."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Mapping
+from typing import Any, TextIO
+
+from pydantic import ValidationError
+
+from tollama.core.protocol import (
+    ProtocolDecodeError,
+    ProtocolErrorMessage,
+    ProtocolRequest,
+    ProtocolResponse,
+    decode_line,
+    encode_line,
+    validate_request,
+)
+from tollama.core.schemas import ForecastRequest
+
+from .adapter import NhitsAdapter
+from .errors import AdapterInputError, DependencyMissingError, NotImplementedRunnerError
+
+RUNNER_NAME = "tollama-nhits"
+RUNNER_VERSION = "0.1.0"
+UNKNOWN_REQUEST_ID = "unknown"
+CAPABILITIES = ("hello", "forecast", "unload")
+_FORECAST_REQUEST_FIELDS = frozenset(
+    {"model", "horizon", "quantiles", "series", "options", "parameters"},
+)
+
+
+def _extract_request_id(payload: Mapping[str, Any] | None) -> str:
+    if payload is not None:
+        request_id = payload.get("id")
+        if isinstance(request_id, str) and request_id:
+            return request_id
+    return UNKNOWN_REQUEST_ID
+
+
+def _error_response(
+    request_id: str,
+    code: int | str,
+    message: str,
+    data: Any | None = None,
+) -> ProtocolResponse:
+    return ProtocolResponse(
+        id=request_id,
+        error=ProtocolErrorMessage(code=code, message=message, data=data),
+    )
+
+
+def _optional_nonempty_str(params: Mapping[str, Any], key: str) -> str | None:
+    value = params.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string when provided")
+    return value.strip()
+
+
+def _optional_string_key_mapping(params: Mapping[str, Any], key: str) -> dict[str, Any] | None:
+    value = params.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{key} must be an object when provided")
+
+    normalized: dict[str, Any] = {}
+    for raw_key, raw_value in value.items():
+        if not isinstance(raw_key, str):
+            raise ValueError(f"{key} keys must be strings")
+        normalized[raw_key] = raw_value
+    return normalized
+
+
+def _handle_hello(request: ProtocolRequest) -> ProtocolResponse:
+    return ProtocolResponse(
+        id=request.id,
+        result={
+            "name": RUNNER_NAME,
+            "version": RUNNER_VERSION,
+            "capabilities": list(CAPABILITIES),
+            "supported_families": ["nhits"],
+            "status": "phase1_placeholder",
+        },
+    )
+
+
+def _handle_unload(request: ProtocolRequest, adapter: NhitsAdapter) -> ProtocolResponse:
+    model_name = request.params.get("model")
+    if model_name is not None and (not isinstance(model_name, str) or not model_name):
+        return _error_response(
+            request.id,
+            code=-32602,
+            message="invalid params",
+            data={"details": "model must be a non-empty string when provided"},
+        )
+    adapter.unload(model_name if isinstance(model_name, str) else None)
+    return ProtocolResponse(
+        id=request.id,
+        result={"unloaded": True, "model": model_name},
+    )
+
+
+def _handle_forecast(request: ProtocolRequest, adapter: NhitsAdapter) -> ProtocolResponse:
+    canonical_params = {
+        key: value for key, value in request.params.items() if key in _FORECAST_REQUEST_FIELDS
+    }
+    try:
+        model_local_dir = _optional_nonempty_str(request.params, "model_local_dir")
+        model_source = _optional_string_key_mapping(request.params, "model_source")
+        model_metadata = _optional_string_key_mapping(request.params, "model_metadata")
+    except ValueError as exc:
+        return _error_response(request.id, code="BAD_REQUEST", message=str(exc))
+
+    try:
+        forecast_request = ForecastRequest.model_validate(canonical_params)
+    except ValidationError as exc:
+        return _error_response(
+            request.id,
+            code=-32602,
+            message="invalid params",
+            data={"details": str(exc)},
+        )
+
+    try:
+        adapter.forecast(
+            forecast_request,
+            model_local_dir=model_local_dir,
+            model_source=model_source,
+            model_metadata=model_metadata,
+        )
+    except DependencyMissingError as exc:
+        return _error_response(request.id, code="DEPENDENCY_MISSING", message=str(exc))
+    except NotImplementedRunnerError as exc:
+        return _error_response(request.id, code="NOT_IMPLEMENTED", message=str(exc))
+    except AdapterInputError as exc:
+        return _error_response(request.id, code="BAD_REQUEST", message=str(exc))
+
+    return _error_response(
+        request.id,
+        code="NOT_IMPLEMENTED",
+        message="N-HiTS placeholder runner did not return a forecast payload",
+    )
+
+
+def handle_request_line(line: str | bytes, adapter: NhitsAdapter) -> ProtocolResponse:
+    payload: Mapping[str, Any] | None = None
+    request_id = UNKNOWN_REQUEST_ID
+
+    try:
+        payload = decode_line(line)
+        request_id = _extract_request_id(payload)
+        request = validate_request(payload)
+    except ProtocolDecodeError as exc:
+        return _error_response(
+            request_id,
+            code=-32600,
+            message="invalid request",
+            data={"details": str(exc)},
+        )
+
+    if request.method == "hello":
+        return _handle_hello(request)
+    if request.method == "forecast":
+        return _handle_forecast(request, adapter)
+    if request.method == "unload":
+        return _handle_unload(request, adapter)
+
+    return _error_response(
+        request.id,
+        code=-32601,
+        message="method not found",
+        data={"method": request.method},
+    )
+
+
+def serve(stdin: TextIO = sys.stdin, stdout: TextIO = sys.stdout) -> int:
+    adapter = NhitsAdapter()
+    for line in stdin:
+        if not line.strip():
+            continue
+        response = handle_request_line(line, adapter)
+        stdout.write(encode_line(response))
+        stdout.flush()
+    return 0
+
+
+def main() -> int:
+    return serve()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_nhits_runner.py
+++ b/tests/test_nhits_runner.py
@@ -1,0 +1,99 @@
+"""Unit tests for N-HiTS runner placeholder behavior."""
+
+from __future__ import annotations
+
+import json
+
+from tollama.runners.nhits_runner.main import handle_request_line
+
+
+class _NoopAdapter:
+    def __init__(self) -> None:
+        self.unloaded_models: list[str | None] = []
+
+    def unload(self, model_name: str | None = None) -> None:
+        self.unloaded_models.append(model_name)
+
+    def forecast(self, request, **kwargs):
+        del request, kwargs
+        raise AssertionError("unexpected call")
+
+
+class _DependencyMissingAdapter(_NoopAdapter):
+    def forecast(self, request, **kwargs):
+        del request, kwargs
+        from tollama.runners.nhits_runner.errors import DependencyMissingError
+
+        raise DependencyMissingError(
+            "install with python -m pip install -e \".[dev,runner_nhits]\"",
+        )
+
+
+class _NotImplementedAdapter(_NoopAdapter):
+    def forecast(self, request, **kwargs):
+        del request, kwargs
+        from tollama.runners.nhits_runner.errors import NotImplementedRunnerError
+
+        raise NotImplementedRunnerError("phase-1 placeholder only")
+
+
+def _forecast_request() -> dict[str, object]:
+    return {
+        "id": "req-2",
+        "method": "forecast",
+        "params": {
+            "model": "nhits",
+            "horizon": 2,
+            "series": [
+                {
+                    "id": "s1",
+                    "freq": "D",
+                    "timestamps": ["2025-01-01", "2025-01-02"],
+                    "target": [1.0, 2.0],
+                }
+            ],
+            "quantiles": [0.1, 0.9],
+            "options": {},
+        },
+    }
+
+
+def test_nhits_runner_hello_reports_supported_family_and_status() -> None:
+    response = handle_request_line(
+        json.dumps({"id": "req-1", "method": "hello", "params": {}}),
+        _NoopAdapter(),
+    )
+    payload = response.model_dump(mode="json", exclude_none=True)
+    assert payload["result"]["supported_families"] == ["nhits"]
+    assert payload["result"]["status"] == "phase1_placeholder"
+
+
+def test_nhits_runner_forecast_returns_dependency_missing_error() -> None:
+    response = handle_request_line(
+        json.dumps(_forecast_request()),
+        _DependencyMissingAdapter(),
+    )
+    payload = response.model_dump(mode="json", exclude_none=True)
+    assert payload["error"]["code"] == "DEPENDENCY_MISSING"
+    assert "runner_nhits" in payload["error"]["message"]
+
+
+def test_nhits_runner_forecast_returns_not_implemented_error() -> None:
+    response = handle_request_line(
+        json.dumps(_forecast_request()),
+        _NotImplementedAdapter(),
+    )
+    payload = response.model_dump(mode="json", exclude_none=True)
+    assert payload["error"]["code"] == "NOT_IMPLEMENTED"
+    assert "placeholder" in payload["error"]["message"]
+
+
+def test_nhits_runner_unload_calls_adapter() -> None:
+    adapter = _NoopAdapter()
+    response = handle_request_line(
+        json.dumps({"id": "req-4", "method": "unload", "params": {"model": "nhits"}}),
+        adapter,
+    )
+    payload = response.model_dump(mode="json", exclude_none=True)
+    assert payload["result"] == {"unloaded": True, "model": "nhits"}
+    assert adapter.unloaded_models == ["nhits"]

--- a/tests/test_registry_storage.py
+++ b/tests/test_registry_storage.py
@@ -31,6 +31,7 @@ def test_registry_loads_required_model_specs() -> None:
         "granite-ttm-r2",
         "patchtst",
         "tide",
+        "nhits",
     } <= set(registry)
 
     mock = registry["mock"]
@@ -149,6 +150,19 @@ def test_registry_loads_required_model_specs() -> None:
         "install_extra": "runner_tide",
         "install_command": 'python -m pip install -e ".[dev,runner_tide]"',
         "notes": "TiDE runner supports deterministic forecasts and best-effort requested quantiles when runtime probabilistic outputs are available. When quantiles cannot be produced, responses explicitly fall back to mean-only forecasts with warnings.",
+    }
+
+    nhits = registry["nhits"]
+    assert nhits.family == "nhits"
+    assert nhits.source.repo_id == "cchallu/nhits-air-passengers"
+    assert nhits.source.revision == "main"
+    assert nhits.metadata == {
+        "implementation": "nhits",
+        "status": "phase1_placeholder",
+        "support_level": "experimental",
+        "install_extra": "runner_nhits",
+        "install_command": 'python -m pip install -e ".[dev,runner_nhits]"',
+        "notes": "N-HiTS is registered for discovery and routing. Phase-1 runner is a capability-gated placeholder and returns explicit DEPENDENCY_MISSING or NOT_IMPLEMENTED guidance until full inference support lands.",
     }
 
     lag_llama = registry["lag-llama"]

--- a/tests/test_runner_manager.py
+++ b/tests/test_runner_manager.py
@@ -130,6 +130,25 @@ def _lag_llama_payload() -> dict[str, object]:
         ],
         "options": {},
     }
+
+
+def _nhits_payload() -> dict[str, object]:
+    return {
+        "model": "nhits",
+        "horizon": 2,
+        "quantiles": [0.1, 0.9],
+        "series": [
+            {
+                "id": "s1",
+                "freq": "D",
+                "timestamps": ["2025-01-01", "2025-01-02"],
+                "target": [10.0, 12.0],
+            }
+        ],
+        "options": {},
+    }
+
+
 def test_daemon_routes_torch_family_to_torch_runner_command_override(monkeypatch, tmp_path) -> None:
     paths = TollamaPaths(base_dir=tmp_path / ".tollama")
     monkeypatch.setenv("TOLLAMA_HOME", str(paths.base_dir))
@@ -377,9 +396,56 @@ def test_missing_patchtst_runner_command_returns_install_hint(monkeypatch, tmp_p
     assert "runner_patchtst" in detail
     assert "pip install -e" in detail
 
+
+def test_daemon_routes_nhits_family_to_runner_command_override(monkeypatch, tmp_path) -> None:
+    paths = TollamaPaths(base_dir=tmp_path / ".tollama")
+    monkeypatch.setenv("TOLLAMA_HOME", str(paths.base_dir))
+    install_from_registry("nhits", accept_license=False, paths=paths)
+
+    manager = RunnerManager(
+        runner_commands={"nhits": ("tollama-runner-mock",)},
+    )
+    with TestClient(create_app(runner_manager=manager)) as client:
+        response = client.post("/v1/forecast", json=_nhits_payload())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["model"] == "nhits"
+    assert body["forecasts"][0]["id"] == "s1"
+    assert body["forecasts"][0]["mean"] == [12.0, 12.0]
+
+
+def test_missing_nhits_runner_command_returns_install_hint(monkeypatch, tmp_path) -> None:
+    paths = TollamaPaths(base_dir=tmp_path / ".tollama")
+    monkeypatch.setenv("TOLLAMA_HOME", str(paths.base_dir))
+    install_from_registry("nhits", accept_license=False, paths=paths)
+
+    manager = RunnerManager(
+        runner_commands={"nhits": ("tollama-runner-nhits-missing",)},
+    )
+    with TestClient(create_app(runner_manager=manager)) as client:
+        response = client.post("/v1/forecast", json=_nhits_payload())
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert "runner-nhits" in detail
+    assert "pip install -e" in detail
+
+
 def test_runner_manager_list_families_includes_expected_defaults() -> None:
     manager = RunnerManager()
-    assert manager.list_families() == ["mock", "torch", "timesfm", "uni2ts", "sundial", "toto", "lag_llama", "patchtst", "tide"]
+    assert manager.list_families() == [
+        "mock",
+        "torch",
+        "timesfm",
+        "uni2ts",
+        "sundial",
+        "toto",
+        "lag_llama",
+        "patchtst",
+        "tide",
+        "nhits",
+    ]
 
 
 def test_runner_manager_get_all_statuses_does_not_start_missing_supervisors(monkeypatch) -> None:
@@ -415,7 +481,18 @@ def test_runner_manager_get_all_statuses_does_not_start_missing_supervisors(monk
     by_family = {item["family"]: item for item in statuses}
 
     assert fake.calls == 1
-    assert set(by_family) == {"mock", "torch", "timesfm", "uni2ts", "sundial", "toto", "lag_llama", "patchtst", "tide"}
+    assert set(by_family) == {
+        "mock",
+        "torch",
+        "timesfm",
+        "uni2ts",
+        "sundial",
+        "toto",
+        "lag_llama",
+        "patchtst",
+        "tide",
+        "nhits",
+    }
     assert by_family["mock"]["running"] is True
     assert by_family["torch"]["command"] == [
         sys.executable,
@@ -459,6 +536,12 @@ def test_runner_manager_get_all_statuses_does_not_start_missing_supervisors(monk
         "tollama.runners.tide_runner.main",
     ]
     assert by_family["tide"]["running"] is False
+    assert by_family["nhits"]["command"] == [
+        sys.executable,
+        "-m",
+        "tollama.runners.nhits_runner.main",
+    ]
+    assert by_family["nhits"]["running"] is False
 
 
 def test_runner_manager_reports_lag_llama_default_command(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add `nhits` to model registry with phase-1 placeholder metadata and install hints
- wire runtime family mapping + runner module hook for the new `nhits` family
- add capability-gated N-HiTS placeholder runner that returns `DEPENDENCY_MISSING` / `NOT_IMPLEMENTED` with actionable guidance
- extend discoverability docs/model listings and add focused tests for registry exposure, runner gating, and manager routing

## Validation
- `PATH="/Users/ychoi/Documents/GitHub/tollama/.venv/bin:$PATH" ./.venv/bin/pytest -q tests/test_nhits_runner.py tests/test_registry_storage.py::test_registry_loads_required_model_specs tests/test_runtime_bootstrap.py::test_list_statuses_covers_all_families tests/test_runner_manager.py::test_daemon_routes_nhits_family_to_runner_command_override tests/test_runner_manager.py::test_missing_nhits_runner_command_returns_install_hint tests/test_runner_manager.py::test_runner_manager_list_families_includes_expected_defaults tests/test_runner_manager.py::test_runner_manager_get_all_statuses_does_not_start_missing_supervisors`
- `./.venv/bin/ruff check src/tollama/runners/nhits_runner tests/test_nhits_runner.py`
