### PR TITLE
feat: nbeatsx phase-2 baseline real inference

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -426,21 +426,26 @@ tollama pull nhits
 ```
 
 
-## N-BEATSx Forecasting (Phase-1 placeholder)
+## N-BEATSx Forecasting (Phase-2 baseline)
 
-N-BEATSx is registered under its own `nbeatsx` runner family for discovery, pull/install, and routing.
+N-BEATSx is integrated for real inference via the dedicated `nbeatsx` runner family.
 
 - model name: `nbeatsx`
 - runner family: `nbeatsx`
 - install extra: `runner_nbeatsx`
 - current runtime behavior:
   - returns `DEPENDENCY_MISSING` with install guidance when optional dependencies are absent
-  - returns `NOT_IMPLEMENTED` after dependency gating because forecast execution is intentionally disabled in phase-1
+  - performs runtime NeuralForecast inference for canonical single/multi-series forecast requests
+  - currently returns point forecasts only (`quantiles` are omitted with warnings)
+  - currently ignores covariates/static features and emits warnings when provided
 
 ```bash
-# install N-BEATSx placeholder runner dependencies
+# install N-BEATSx runner dependencies
 python -m pip install -e ".[dev,runner_nbeatsx]"
 
 # pull registry entry
 tollama pull nbeatsx
+
+# run forecast
+tollama run nbeatsx --input examples/request.json --no-stream
 ```

--- a/model-registry/registry.yaml
+++ b/model-registry/registry.yaml
@@ -243,11 +243,11 @@ models:
       needs_acceptance: false
     metadata:
       implementation: nbeatsx
-      status: phase1_placeholder
-      support_level: experimental
+      status: phase2_inference
+      support_level: baseline
       install_extra: runner_nbeatsx
       install_command: python -m pip install -e ".[dev,runner_nbeatsx]"
-      notes: N-BEATSx is registered for discovery and routing. Phase-1 runner is a capability-gated placeholder and returns explicit DEPENDENCY_MISSING or NOT_IMPLEMENTED guidance until full inference support lands.
+      notes: N-BEATSx runner supports canonical point forecasts (single/multi series) via runtime NeuralForecast inference. Requested quantiles and covariates are currently best-effort limitations and return explicit response warnings.
     capabilities:
       past_covariates_numeric: false
       past_covariates_categorical: false

--- a/src/tollama/runners/nbeatsx_runner/adapter.py
+++ b/src/tollama/runners/nbeatsx_runner/adapter.py
@@ -1,19 +1,45 @@
-"""Phase-1 placeholder adapter for N-BEATSx runner."""
+"""N-BEATSx forecasting adapter used by the nbeatsx runner."""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
-from tollama.core.schemas import ForecastRequest
+from tollama.core.schemas import ForecastRequest, ForecastResponse, SeriesForecast, SeriesInput
 
-from .errors import DependencyMissingError, NotImplementedRunnerError
+from .errors import AdapterInputError, DependencyMissingError, UnsupportedModelError
 
-_INSTALL_HINT = 'python -m pip install -e ".[dev,runner_nbeatsx]"'
+_NBEATSX_MODELS: dict[str, dict[str, Any]] = {
+    "nbeatsx": {
+        "repo_id": "cchallu/nbeatsx-air-passengers",
+        "revision": "main",
+        "implementation": "nbeatsx",
+    },
+}
+
+
+@dataclass(frozen=True)
+class _Dependencies:
+    pd: Any
+    neuralforecast_cls: Any
+    nbeatsx_cls: Any
+
+
+@dataclass(frozen=True)
+class _RuntimeConfig:
+    model_name: str
+    repo_id: str
+    revision: str
+    implementation: str
 
 
 class NbeatsxAdapter:
-    """Capability-gated placeholder adapter for initial N-BEATSx integration."""
+    """Adapter mapping canonical forecast payloads to NeuralForecast N-BEATSx."""
+
+    def __init__(self) -> None:
+        self._dependencies: _Dependencies | None = None
 
     def unload(self, model_name: str | None = None) -> None:
         del model_name
@@ -23,27 +49,258 @@ class NbeatsxAdapter:
         request: ForecastRequest,
         *,
         model_local_dir: str | None = None,
-        model_source: Mapping[str, Any] | None = None,
-        model_metadata: Mapping[str, Any] | None = None,
-    ) -> None:
-        del request, model_local_dir, model_source
-
-        metadata = dict(model_metadata or {})
-        status = str(metadata.get("status") or "").strip().lower()
-        if status and status != "phase1_placeholder":
-            raise NotImplementedRunnerError(
-                "N-BEATSx runner implementation is not available yet for status "
-                f"{status!r}. Track progress in tollama milestones.",
-            )
-
-        if metadata.get("dependency_probe", True):
-            raise DependencyMissingError(
-                "N-BEATSx Phase-1 baseline is scaffolded but optional runtime dependencies "
-                f"are not installed yet. Install with `{_INSTALL_HINT}` and retry.",
-            )
-
-        raise NotImplementedRunnerError(
-            "N-BEATSx Phase-1 baseline runner is discoverable and routable, but forecast "
-            "execution is intentionally disabled. Full inference will land in a follow-up "
-            "phase.",
+        model_source: dict[str, Any] | None = None,
+        model_metadata: dict[str, Any] | None = None,
+    ) -> ForecastResponse:
+        runtime = _resolve_runtime_config(
+            model_name=request.model,
+            model_source=model_source,
+            model_metadata=model_metadata,
         )
+        deps = self._resolve_dependencies()
+
+        train_df = _request_to_training_frame(request=request, pd_module=deps.pd)
+        model = _build_model(request=request, runtime=runtime, nbeatsx_cls=deps.nbeatsx_cls)
+        predictor = deps.neuralforecast_cls(models=[model], freq=request.series[0].freq)
+
+        try:
+            predictor.fit(train_df)
+            prediction = predictor.predict(h=request.horizon)
+        except Exception as exc:  # noqa: BLE001
+            raise AdapterInputError(f"N-BEATSx forecast failed: {exc}") from exc
+
+        by_id = _prediction_to_id_map(prediction)
+        forecasts: list[SeriesForecast] = []
+        for series in request.series:
+            mean = by_id.get(series.id)
+            if mean is None:
+                raise AdapterInputError(
+                    f"N-BEATSx output missing forecast for series {series.id!r}",
+                )
+            forecasts.append(
+                SeriesForecast(
+                    id=series.id,
+                    freq=series.freq,
+                    start_timestamp=_future_start_timestamp(
+                        series=series,
+                        horizon=request.horizon,
+                        pd_module=deps.pd,
+                    ),
+                    mean=mean,
+                    quantiles=None,
+                ),
+            )
+
+        warnings = _build_limitations_warnings(
+            request=request,
+            model_local_dir=model_local_dir,
+        )
+
+        return ForecastResponse(
+            model=request.model,
+            forecasts=forecasts,
+            usage={
+                "runner": "tollama-nbeatsx",
+                "implementation": runtime.implementation,
+                "series_count": len(forecasts),
+                "horizon": request.horizon,
+                "repo_id": runtime.repo_id,
+                "revision": runtime.revision,
+            },
+            warnings=warnings or None,
+        )
+
+    def _resolve_dependencies(self) -> _Dependencies:
+        if self._dependencies is not None:
+            return self._dependencies
+
+        missing: list[str] = []
+        try:
+            import pandas as pd
+        except ModuleNotFoundError as exc:
+            missing.append(exc.name or "pandas")
+            pd = None
+
+        neuralforecast_cls = None
+        nbeatsx_cls = None
+        try:
+            from neuralforecast import NeuralForecast
+            from neuralforecast.models import NBEATSx
+
+            neuralforecast_cls = NeuralForecast
+            nbeatsx_cls = NBEATSx
+        except ModuleNotFoundError as exc:
+            missing.append(exc.name or "neuralforecast")
+
+        if missing or pd is None or neuralforecast_cls is None or nbeatsx_cls is None:
+            joined = ", ".join(sorted(set(missing or ["neuralforecast"])))
+            raise DependencyMissingError(
+                "missing optional nbeatsx runner dependencies "
+                f"({joined}); install them with `pip install -e \".[dev,runner_nbeatsx]\"`",
+            )
+
+        deps = _Dependencies(
+            pd=pd,
+            neuralforecast_cls=neuralforecast_cls,
+            nbeatsx_cls=nbeatsx_cls,
+        )
+        self._dependencies = deps
+        return deps
+
+
+def _request_to_training_frame(*, request: ForecastRequest, pd_module: Any) -> Any:
+    rows: list[dict[str, Any]] = []
+    for series in request.series:
+        if len(series.timestamps) != len(series.target):
+            raise AdapterInputError(f"series {series.id!r} timestamps and target lengths must match")
+        if len(series.target) < 2:
+            raise AdapterInputError("each input series must include at least two target points")
+
+        for timestamp, value in zip(series.timestamps, series.target, strict=True):
+            rows.append({"unique_id": series.id, "ds": timestamp, "y": float(value)})
+
+    frame = pd_module.DataFrame(rows)
+    try:
+        frame["ds"] = pd_module.to_datetime(frame["ds"], utc=True, errors="raise")
+    except Exception as exc:  # noqa: BLE001
+        raise AdapterInputError(f"invalid timestamps for nbeatsx request: {exc}") from exc
+    return frame
+
+
+def _build_model(*, request: ForecastRequest, runtime: _RuntimeConfig, nbeatsx_cls: Any) -> Any:
+    input_size = max(2 * request.horizon, 4)
+    try:
+        return nbeatsx_cls(h=request.horizon, input_size=input_size)
+    except Exception as exc:  # noqa: BLE001
+        raise AdapterInputError(
+            f"failed to initialize N-BEATSx model for {runtime.model_name!r}: {exc}",
+        ) from exc
+
+
+def _prediction_to_id_map(prediction: Any) -> dict[str, list[float]]:
+    if hasattr(prediction, "to_dict"):
+        rows = prediction.to_dict(orient="records")
+    elif isinstance(prediction, list):
+        rows = prediction
+    else:
+        raise AdapterInputError("N-BEATSx prediction output has unexpected shape")
+
+    by_id: dict[str, list[float]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        series_id = row.get("unique_id")
+        if not isinstance(series_id, str) or not series_id:
+            continue
+        value = _extract_prediction_value(row)
+        if value is None:
+            continue
+        by_id.setdefault(series_id, []).append(value)
+
+    return by_id
+
+
+def _extract_prediction_value(row: dict[str, Any]) -> float | None:
+    for key, value in row.items():
+        if key in {"unique_id", "ds"}:
+            continue
+        if isinstance(value, bool):
+            return float(int(value))
+        if isinstance(value, (int, float)):
+            return float(value)
+        if hasattr(value, "item"):
+            scalar = value.item()
+            if isinstance(scalar, bool):
+                return float(int(scalar))
+            if isinstance(scalar, (int, float)):
+                return float(scalar)
+    return None
+
+
+def _build_limitations_warnings(*, request: ForecastRequest, model_local_dir: str | None) -> list[str]:
+    warnings: list[str] = []
+
+    if request.quantiles:
+        warnings.append(
+            "N-BEATSx baseline currently returns point forecasts only; requested quantiles were omitted",
+        )
+
+    if any(
+        series.past_covariates or series.future_covariates or series.static_covariates
+        for series in request.series
+    ):
+        warnings.append(
+            "N-BEATSx baseline currently ignores covariates and static features; "
+            "using target-only history",
+        )
+
+    if model_local_dir:
+        path = Path(model_local_dir.strip())
+        if path.exists():
+            warnings.append(
+                "N-BEATSx baseline trains from request history at runtime; "
+                "model_local_dir is currently ignored",
+            )
+
+    return warnings
+
+
+def _future_start_timestamp(*, series: SeriesInput, horizon: int, pd_module: Any) -> str:
+    try:
+        parsed = pd_module.to_datetime([series.timestamps[-1]], utc=True, errors="raise")
+        generated = pd_module.date_range(start=parsed[0], periods=horizon + 1, freq=series.freq)
+    except Exception as exc:  # noqa: BLE001
+        raise AdapterInputError(f"invalid frequency {series.freq!r} for nbeatsx forecast") from exc
+    return _to_iso_timestamp(generated[1])
+
+
+def _to_iso_timestamp(value: Any) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat()).replace("+00:00", "Z")
+    return str(value)
+
+
+def _resolve_runtime_config(
+    *,
+    model_name: str,
+    model_source: dict[str, Any] | None,
+    model_metadata: dict[str, Any] | None,
+) -> _RuntimeConfig:
+    defaults = _NBEATSX_MODELS.get(model_name, {})
+    repo_id = _dict_str(model_source, "repo_id") or _string_or_none(defaults.get("repo_id"))
+    revision = _dict_str(model_source, "revision") or _string_or_none(defaults.get("revision")) or "main"
+    implementation = (
+        _dict_str(model_metadata, "implementation")
+        or _string_or_none(defaults.get("implementation"))
+        or "nbeatsx"
+    )
+
+    if repo_id is None:
+        raise UnsupportedModelError(f"unsupported nbeatsx model {model_name!r}; missing repo_id")
+
+    return _RuntimeConfig(
+        model_name=model_name,
+        repo_id=repo_id,
+        revision=revision,
+        implementation=implementation,
+    )
+
+
+def _dict_str(payload: dict[str, Any] | None, key: str) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    return _string_or_none(payload.get(key))
+
+
+def _string_or_none(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    return normalized

--- a/src/tollama/runners/nbeatsx_runner/errors.py
+++ b/src/tollama/runners/nbeatsx_runner/errors.py
@@ -13,3 +13,7 @@ class NotImplementedRunnerError(RuntimeError):
 
 class AdapterInputError(ValueError):
     """Raised when request input is invalid for the N-BEATSx adapter."""
+
+
+class UnsupportedModelError(ValueError):
+    """Raised when model metadata/source is incompatible with N-BEATSx adapter."""

--- a/src/tollama/runners/nbeatsx_runner/main.py
+++ b/src/tollama/runners/nbeatsx_runner/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import time
 from collections.abc import Mapping
 from typing import Any, TextIO
 
@@ -18,14 +19,16 @@ from tollama.core.protocol import (
     validate_request,
 )
 from tollama.core.schemas import ForecastRequest
+from tollama.runners.runtime_telemetry import enrich_forecast_response
 
 from .adapter import NbeatsxAdapter
-from .errors import AdapterInputError, DependencyMissingError, NotImplementedRunnerError
+from .errors import AdapterInputError, DependencyMissingError, UnsupportedModelError
 
 RUNNER_NAME = "tollama-nbeatsx"
-RUNNER_VERSION = "0.1.0"
+RUNNER_VERSION = "0.2.0"
 UNKNOWN_REQUEST_ID = "unknown"
 CAPABILITIES = ("hello", "forecast", "unload")
+_SUPPORTED_FAMILIES = ["nbeatsx"]
 _FORECAST_REQUEST_FIELDS = frozenset(
     {"model", "horizon", "quantiles", "series", "options", "parameters"},
 )
@@ -82,8 +85,8 @@ def _handle_hello(request: ProtocolRequest) -> ProtocolResponse:
             "name": RUNNER_NAME,
             "version": RUNNER_VERSION,
             "capabilities": list(CAPABILITIES),
-            "supported_families": ["nbeatsx"],
-            "status": "phase1_placeholder",
+            "supported_families": _SUPPORTED_FAMILIES,
+            "status": "phase2_inference",
         },
     )
 
@@ -126,24 +129,29 @@ def _handle_forecast(request: ProtocolRequest, adapter: NbeatsxAdapter) -> Proto
         )
 
     try:
-        adapter.forecast(
+        started_at = time.perf_counter()
+        response = adapter.forecast(
             forecast_request,
             model_local_dir=model_local_dir,
             model_source=model_source,
             model_metadata=model_metadata,
         )
+        inference_ms = (time.perf_counter() - started_at) * 1000.0
     except DependencyMissingError as exc:
         return _error_response(request.id, code="DEPENDENCY_MISSING", message=str(exc))
-    except NotImplementedRunnerError as exc:
-        return _error_response(request.id, code="NOT_IMPLEMENTED", message=str(exc))
+    except UnsupportedModelError as exc:
+        return _error_response(request.id, code="MODEL_UNSUPPORTED", message=str(exc))
     except AdapterInputError as exc:
         return _error_response(request.id, code="BAD_REQUEST", message=str(exc))
+    except ValueError as exc:
+        return _error_response(request.id, code="FORECAST_ERROR", message=str(exc))
 
-    return _error_response(
-        request.id,
-        code="NOT_IMPLEMENTED",
-        message="N-BEATSx placeholder runner did not return a forecast payload",
+    response = enrich_forecast_response(
+        response=response,
+        runner_name=RUNNER_NAME,
+        inference_ms=inference_ms,
     )
+    return ProtocolResponse(id=request.id, result=response.model_dump(mode="json", exclude_none=True))
 
 
 def handle_request_line(line: str | bytes, adapter: NbeatsxAdapter) -> ProtocolResponse:

--- a/tests/test_nbeatsx_adapter.py
+++ b/tests/test_nbeatsx_adapter.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tollama.core.schemas import ForecastRequest
+from tollama.runners.nbeatsx_runner.adapter import NbeatsxAdapter
+
+
+class _FakeDate:
+    def __init__(self, iso: str) -> None:
+        self._iso = iso
+
+    def isoformat(self) -> str:
+        return self._iso
+
+
+class _FakeDataFrame:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def __getitem__(self, key: str) -> list[Any]:
+        return [row.get(key) for row in self.rows]
+
+    def __setitem__(self, key: str, values: list[Any]) -> None:
+        for row, value in zip(self.rows, values, strict=True):
+            row[key] = value
+
+    def to_dict(self, orient: str) -> list[dict[str, Any]]:
+        assert orient == "records"
+        return self.rows
+
+
+class _FakePandas:
+    @staticmethod
+    def DataFrame(rows: list[dict[str, Any]]) -> _FakeDataFrame:
+        return _FakeDataFrame(rows)
+
+    @staticmethod
+    def to_datetime(values: list[str], utc: bool = True, errors: str = "raise") -> list[str]:
+        del utc, errors
+        return values
+
+    @staticmethod
+    def date_range(start: Any, periods: int, freq: str) -> list[_FakeDate]:
+        del start
+        if freq != "D":
+            raise ValueError("unsupported")
+        return [_FakeDate(f"2025-01-{index:02d}T00:00:00+00:00") for index in range(1, periods + 1)]
+
+
+class _FakeNF:
+    def __init__(self, models: list[Any], freq: str) -> None:
+        self._models = models
+        self._freq = freq
+
+    def fit(self, train_df: _FakeDataFrame) -> None:
+        del train_df
+
+    def predict(self, h: int) -> _FakeDataFrame:
+        del h
+        return _FakeDataFrame(
+            [
+                {"unique_id": "s1", "ds": "2025-01-04", "NBEATSx": 10.0},
+                {"unique_id": "s1", "ds": "2025-01-05", "NBEATSx": 11.0},
+                {"unique_id": "s2", "ds": "2025-01-04", "NBEATSx": 20.0},
+                {"unique_id": "s2", "ds": "2025-01-05", "NBEATSx": 21.0},
+            ],
+        )
+
+
+class _FakeNBEATSx:
+    def __init__(self, h: int, input_size: int) -> None:
+        self.h = h
+        self.input_size = input_size
+
+
+def _request() -> ForecastRequest:
+    return ForecastRequest.model_validate(
+        {
+            "model": "nbeatsx",
+            "horizon": 2,
+            "quantiles": [0.1, 0.9],
+            "series": [
+                {
+                    "id": "s1",
+                    "freq": "D",
+                    "timestamps": ["2025-01-01", "2025-01-02", "2025-01-03"],
+                    "target": [1.0, 2.0, 3.0],
+                },
+                {
+                    "id": "s2",
+                    "freq": "D",
+                    "timestamps": ["2025-01-01", "2025-01-02", "2025-01-03"],
+                    "target": [3.0, 2.0, 1.0],
+                    "past_covariates": {"promo": [0, 1, 1]},
+                },
+            ],
+            "options": {},
+        },
+    )
+
+
+def test_nbeatsx_adapter_forecast_smoke_multi_series(monkeypatch) -> None:
+    adapter = NbeatsxAdapter()
+    monkeypatch.setattr(
+        adapter,
+        "_resolve_dependencies",
+        lambda: type(
+            "D",
+            (),
+            {"pd": _FakePandas(), "neuralforecast_cls": _FakeNF, "nbeatsx_cls": _FakeNBEATSx},
+        )(),
+    )
+
+    response = adapter.forecast(_request(), model_local_dir="/tmp")
+
+    assert response.model == "nbeatsx"
+    assert len(response.forecasts) == 2
+    assert response.forecasts[0].mean == [10.0, 11.0]
+    assert response.forecasts[1].mean == [20.0, 21.0]
+    assert response.forecasts[0].quantiles is None
+    assert response.usage is not None
+    assert response.usage["runner"] == "tollama-nbeatsx"
+    assert response.warnings is not None
+    assert any("point forecasts only" in warning for warning in response.warnings)
+    assert any("ignores covariates" in warning for warning in response.warnings)
+
+
+def test_nbeatsx_adapter_invalid_frequency_maps_to_input_error(monkeypatch) -> None:
+    from tollama.runners.nbeatsx_runner.errors import AdapterInputError
+
+    adapter = NbeatsxAdapter()
+    monkeypatch.setattr(
+        adapter,
+        "_resolve_dependencies",
+        lambda: type(
+            "D",
+            (),
+            {"pd": _FakePandas(), "neuralforecast_cls": _FakeNF, "nbeatsx_cls": _FakeNBEATSx},
+        )(),
+    )
+    req = _request()
+    req.series[0].freq = "BAD"
+
+    try:
+        adapter.forecast(req)
+        raise AssertionError("expected AdapterInputError")
+    except AdapterInputError as exc:
+        assert "invalid frequency" in str(exc)

--- a/tests/test_nbeatsx_runner.py
+++ b/tests/test_nbeatsx_runner.py
@@ -1,95 +1,144 @@
-"""Unit tests for N-BEATSx runner placeholder behavior."""
+"""Unit tests for N-BEATSx runner process wiring."""
 
 from __future__ import annotations
 
 import json
+from typing import Any
 
+from tollama.core.schemas import ForecastResponse, SeriesForecast
+from tollama.runners.nbeatsx_runner.errors import DependencyMissingError
 from tollama.runners.nbeatsx_runner.main import handle_request_line
 
 
-class _NoopAdapter:
+class _CapturingAdapter:
     def __init__(self) -> None:
         self.unloaded_models: list[str | None] = []
+        self.forecast_calls: list[dict[str, Any]] = []
 
     def unload(self, model_name: str | None = None) -> None:
         self.unloaded_models.append(model_name)
 
-    def forecast(self, request, **kwargs):
-        del request, kwargs
-        raise AssertionError("unexpected call")
-
-
-class _DependencyMissingAdapter(_NoopAdapter):
-    def forecast(self, request, **kwargs):
-        del request, kwargs
-        from tollama.runners.nbeatsx_runner.errors import DependencyMissingError
-
-        raise DependencyMissingError(
-            "install with python -m pip install -e \".[dev,runner_nbeatsx]\"",
+    def forecast(
+        self,
+        request,
+        *,
+        model_local_dir: str | None = None,
+        model_source: dict[str, object] | None = None,
+        model_metadata: dict[str, object] | None = None,
+    ) -> ForecastResponse:
+        self.forecast_calls.append(
+            {
+                "request": request,
+                "model_local_dir": model_local_dir,
+                "model_source": model_source,
+                "model_metadata": model_metadata,
+            },
+        )
+        return ForecastResponse(
+            model=request.model,
+            forecasts=[
+                SeriesForecast(
+                    id=request.series[0].id,
+                    freq=request.series[0].freq,
+                    start_timestamp="2025-01-03T00:00:00Z",
+                    mean=[2.0, 2.0],
+                    quantiles=None,
+                ),
+            ],
+            usage={"runner": "tollama-nbeatsx"},
+            warnings=["point forecasts only"],
         )
 
 
-class _NotImplementedAdapter(_NoopAdapter):
-    def forecast(self, request, **kwargs):
-        del request, kwargs
-        from tollama.runners.nbeatsx_runner.errors import NotImplementedRunnerError
+class _MissingDependencyAdapter(_CapturingAdapter):
+    def forecast(
+        self,
+        request,
+        *,
+        model_local_dir: str | None = None,
+        model_source: dict[str, object] | None = None,
+        model_metadata: dict[str, object] | None = None,
+    ) -> ForecastResponse:
+        del request, model_local_dir, model_source, model_metadata
+        raise DependencyMissingError(
+            "missing optional nbeatsx runner dependencies (neuralforecast); "
+            "install them with `pip install -e \".[dev,runner_nbeatsx]\"`",
+        )
 
-        raise NotImplementedRunnerError("phase-1 placeholder only")
 
-
-def _forecast_request() -> dict[str, object]:
+def _valid_forecast_params() -> dict[str, Any]:
     return {
-        "id": "req-2",
-        "method": "forecast",
-        "params": {
-            "model": "nbeatsx",
-            "horizon": 2,
-            "series": [
-                {
-                    "id": "s1",
-                    "freq": "D",
-                    "timestamps": ["2025-01-01", "2025-01-02"],
-                    "target": [1.0, 2.0],
-                }
-            ],
-            "quantiles": [0.1, 0.9],
-            "options": {},
-        },
+        "model": "nbeatsx",
+        "horizon": 2,
+        "quantiles": [0.1, 0.9],
+        "series": [
+            {
+                "id": "s1",
+                "freq": "D",
+                "timestamps": ["2025-01-01", "2025-01-02"],
+                "target": [1.0, 2.0],
+            }
+        ],
+        "options": {},
     }
 
 
 def test_nbeatsx_runner_hello_reports_supported_family_and_status() -> None:
     response = handle_request_line(
         json.dumps({"id": "req-1", "method": "hello", "params": {}}),
-        _NoopAdapter(),
+        _CapturingAdapter(),
     )
     payload = response.model_dump(mode="json", exclude_none=True)
     assert payload["result"]["supported_families"] == ["nbeatsx"]
-    assert payload["result"]["status"] == "phase1_placeholder"
+    assert payload["result"]["status"] == "phase2_inference"
 
 
 def test_nbeatsx_runner_forecast_returns_dependency_missing_error() -> None:
     response = handle_request_line(
-        json.dumps(_forecast_request()),
-        _DependencyMissingAdapter(),
+        json.dumps(
+            {
+                "id": "req-2",
+                "method": "forecast",
+                "params": _valid_forecast_params(),
+            },
+        ),
+        _MissingDependencyAdapter(),
     )
     payload = response.model_dump(mode="json", exclude_none=True)
+    assert payload["id"] == "req-2"
     assert payload["error"]["code"] == "DEPENDENCY_MISSING"
     assert "runner_nbeatsx" in payload["error"]["message"]
 
 
-def test_nbeatsx_runner_forecast_returns_not_implemented_error() -> None:
+def test_nbeatsx_runner_forecast_smoke_wires_request_and_response() -> None:
+    adapter = _CapturingAdapter()
+    params = _valid_forecast_params()
+    params["model_local_dir"] = " /tmp/nbeatsx "
+    params["model_source"] = {"repo_id": "cchallu/nbeatsx-air-passengers", "revision": "main"}
+    params["model_metadata"] = {"implementation": "nbeatsx"}
+
     response = handle_request_line(
-        json.dumps(_forecast_request()),
-        _NotImplementedAdapter(),
+        json.dumps({"id": "req-3", "method": "forecast", "params": params}),
+        adapter,
     )
     payload = response.model_dump(mode="json", exclude_none=True)
-    assert payload["error"]["code"] == "NOT_IMPLEMENTED"
-    assert "placeholder" in payload["error"]["message"]
+
+    assert payload["id"] == "req-3"
+    assert payload["result"]["model"] == "nbeatsx"
+    assert payload["result"]["forecasts"][0]["id"] == "s1"
+    assert payload["result"]["forecasts"][0]["mean"] == [2.0, 2.0]
+
+    assert len(adapter.forecast_calls) == 1
+    call = adapter.forecast_calls[0]
+    assert call["request"].model == "nbeatsx"
+    assert call["request"].horizon == 2
+    assert call["model_local_dir"] == "/tmp/nbeatsx"
+    assert call["model_source"] == {"repo_id": "cchallu/nbeatsx-air-passengers", "revision": "main"}
+    assert call["model_metadata"] == {"implementation": "nbeatsx"}
 
 
 def test_nbeatsx_runner_unload_calls_adapter() -> None:
-    adapter = _NoopAdapter()
+    adapter = _CapturingAdapter()
     response = handle_request_line(
         json.dumps({"id": "req-4", "method": "unload", "params": {"model": "nbeatsx"}}),
         adapter,

--- a/tests/test_registry_storage.py
+++ b/tests/test_registry_storage.py
@@ -185,14 +185,15 @@ def test_registry_loads_required_model_specs() -> None:
     assert nbeatsx.source.revision == "main"
     assert nbeatsx.metadata == {
         "implementation": "nbeatsx",
-        "status": "phase1_placeholder",
-        "support_level": "experimental",
+        "status": "phase2_inference",
+        "support_level": "baseline",
         "install_extra": "runner_nbeatsx",
         "install_command": 'python -m pip install -e ".[dev,runner_nbeatsx]"',
         "notes": (
-            "N-BEATSx is registered for discovery and routing. Phase-1 runner is a "
-            "capability-gated placeholder and returns explicit DEPENDENCY_MISSING or "
-            "NOT_IMPLEMENTED guidance until full inference support lands."
+            "N-BEATSx runner supports canonical point forecasts (single/multi series) "
+            "via runtime NeuralForecast inference. Requested quantiles and covariates "
+            "are currently best-effort limitations and return explicit response "
+            "warnings."
         ),
     }
 


### PR DESCRIPTION
## Summary
- replace N-BEATSx phase-1 placeholder with a phase-2 baseline runtime inference path
- keep dependency gating with `runner_nbeatsx` install hints
- wire canonical forecast request/response handling in runner main + runtime telemetry
- add adapter/runner tests and update registry metadata + docs to phase-2 behavior

## Notes
- baseline uses runtime NeuralForecast fitting per request from provided history
- quantiles and covariates are currently unsupported in output and returned as explicit warnings

## Validation
- `PYTHONPATH=src pytest -q tests/test_nbeatsx_adapter.py tests/test_nbeatsx_runner.py tests/test_registry_storage.py`
- smoke demo: monkeypatched adapter invocation printing canonical forecast response payload
