### PR TITLE
feat(nbeatsx): phase-3 hardening for input/frequency edge cases

### DIFF
--- a/src/tollama/runners/nbeatsx_runner/adapter.py
+++ b/src/tollama/runners/nbeatsx_runner/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -59,9 +60,10 @@ class NbeatsxAdapter:
         )
         deps = self._resolve_dependencies()
 
+        resolved_freq = _resolve_shared_frequency(request=request, pd_module=deps.pd)
         train_df = _request_to_training_frame(request=request, pd_module=deps.pd)
         model = _build_model(request=request, runtime=runtime, nbeatsx_cls=deps.nbeatsx_cls)
-        predictor = deps.neuralforecast_cls(models=[model], freq=request.series[0].freq)
+        predictor = deps.neuralforecast_cls(models=[model], freq=resolved_freq)
 
         try:
             predictor.fit(train_df)
@@ -80,11 +82,12 @@ class NbeatsxAdapter:
             forecasts.append(
                 SeriesForecast(
                     id=series.id,
-                    freq=series.freq,
+                    freq=resolved_freq,
                     start_timestamp=_future_start_timestamp(
                         series=series,
                         horizon=request.horizon,
                         pd_module=deps.pd,
+                        resolved_freq=resolved_freq,
                     ),
                     mean=mean,
                     quantiles=None,
@@ -156,8 +159,14 @@ def _request_to_training_frame(*, request: ForecastRequest, pd_module: Any) -> A
         if len(series.target) < 2:
             raise AdapterInputError("each input series must include at least two target points")
 
-        for timestamp, value in zip(series.timestamps, series.target, strict=True):
-            rows.append({"unique_id": series.id, "ds": timestamp, "y": float(value)})
+        for index, (timestamp, value) in enumerate(zip(series.timestamps, series.target, strict=True)):
+            rows.append(
+                {
+                    "unique_id": series.id,
+                    "ds": timestamp,
+                    "y": _coerce_finite_float(value, field=f"series {series.id!r} target[{index}]"),
+                },
+            )
 
     frame = pd_module.DataFrame(rows)
     try:
@@ -245,13 +254,66 @@ def _build_limitations_warnings(*, request: ForecastRequest, model_local_dir: st
     return warnings
 
 
-def _future_start_timestamp(*, series: SeriesInput, horizon: int, pd_module: Any) -> str:
+def _future_start_timestamp(*, series: SeriesInput, horizon: int, pd_module: Any, resolved_freq: str) -> str:
     try:
         parsed = pd_module.to_datetime([series.timestamps[-1]], utc=True, errors="raise")
-        generated = pd_module.date_range(start=parsed[0], periods=horizon + 1, freq=series.freq)
+        generated = pd_module.date_range(start=parsed[0], periods=horizon + 1, freq=resolved_freq)
     except Exception as exc:  # noqa: BLE001
         raise AdapterInputError(f"invalid frequency {series.freq!r} for nbeatsx forecast") from exc
     return _to_iso_timestamp(generated[1])
+
+
+def _resolve_shared_frequency(*, request: ForecastRequest, pd_module: Any) -> str:
+    resolved: str | None = None
+    for series in request.series:
+        freq = _normalize_frequency(series=series, pd_module=pd_module)
+        if resolved is None:
+            resolved = freq
+            continue
+        if freq != resolved:
+            raise AdapterInputError(
+                "N-BEATSx currently requires one shared frequency across all series in a request",
+            )
+    if resolved is None:
+        raise AdapterInputError("nbeatsx forecast requires at least one input series")
+    return resolved
+
+
+def _normalize_frequency(*, series: SeriesInput, pd_module: Any) -> str:
+    freq = (series.freq or "").strip()
+    if freq.lower() == "auto":
+        infer_freq = getattr(pd_module, "infer_freq", None)
+        if not callable(infer_freq):
+            raise AdapterInputError(
+                f"unable to infer frequency for series {series.id!r}; provide explicit freq",
+            )
+        try:
+            parsed = pd_module.to_datetime(series.timestamps, utc=True, errors="raise")
+            inferred = infer_freq(parsed)
+        except Exception as exc:  # noqa: BLE001
+            raise AdapterInputError(f"invalid timestamps for series {series.id!r}: {exc}") from exc
+        if not inferred:
+            raise AdapterInputError(
+                f"unable to infer frequency for series {series.id!r}; provide explicit freq",
+            )
+        freq = str(inferred)
+
+    try:
+        parsed = pd_module.to_datetime([series.timestamps[-1]], utc=True, errors="raise")
+        pd_module.date_range(start=parsed[0], periods=2, freq=freq)
+    except Exception as exc:  # noqa: BLE001
+        raise AdapterInputError(f"invalid frequency {series.freq!r} for nbeatsx forecast") from exc
+    return freq
+
+
+def _coerce_finite_float(value: Any, *, field: str) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise AdapterInputError(f"{field} must be numeric") from exc
+    if not math.isfinite(numeric):
+        raise AdapterInputError(f"{field} must be finite")
+    return numeric
 
 
 def _to_iso_timestamp(value: Any) -> str:

--- a/tests/test_nbeatsx_adapter.py
+++ b/tests/test_nbeatsx_adapter.py
@@ -41,9 +41,14 @@ class _FakePandas:
         return values
 
     @staticmethod
+    def infer_freq(values: list[str]) -> str | None:
+        del values
+        return "D"
+
+    @staticmethod
     def date_range(start: Any, periods: int, freq: str) -> list[_FakeDate]:
         del start
-        if freq != "D":
+        if freq not in {"D", "H"}:
             raise ValueError("unsupported")
         return [_FakeDate(f"2025-01-{index:02d}T00:00:00+00:00") for index in range(1, periods + 1)]
 
@@ -147,3 +152,49 @@ def test_nbeatsx_adapter_invalid_frequency_maps_to_input_error(monkeypatch) -> N
         raise AssertionError("expected AdapterInputError")
     except AdapterInputError as exc:
         assert "invalid frequency" in str(exc)
+
+
+def test_nbeatsx_adapter_rejects_non_finite_target(monkeypatch) -> None:
+    from tollama.runners.nbeatsx_runner.errors import AdapterInputError
+
+    adapter = NbeatsxAdapter()
+    monkeypatch.setattr(
+        adapter,
+        "_resolve_dependencies",
+        lambda: type(
+            "D",
+            (),
+            {"pd": _FakePandas(), "neuralforecast_cls": _FakeNF, "nbeatsx_cls": _FakeNBEATSx},
+        )(),
+    )
+    req = _request()
+    req.series[0].target[0] = float("nan")
+
+    try:
+        adapter.forecast(req)
+        raise AssertionError("expected AdapterInputError")
+    except AdapterInputError as exc:
+        assert "must be finite" in str(exc)
+
+
+def test_nbeatsx_adapter_rejects_mixed_multi_series_frequency(monkeypatch) -> None:
+    from tollama.runners.nbeatsx_runner.errors import AdapterInputError
+
+    adapter = NbeatsxAdapter()
+    monkeypatch.setattr(
+        adapter,
+        "_resolve_dependencies",
+        lambda: type(
+            "D",
+            (),
+            {"pd": _FakePandas(), "neuralforecast_cls": _FakeNF, "nbeatsx_cls": _FakeNBEATSx},
+        )(),
+    )
+    req = _request()
+    req.series[1].freq = "H"
+
+    try:
+        adapter.forecast(req)
+        raise AssertionError("expected AdapterInputError")
+    except AdapterInputError as exc:
+        assert "shared frequency" in str(exc)


### PR DESCRIPTION
## Summary
- harden N-BEATSx phase-2 path with finite numeric target validation and clearer per-point errors
- enforce/normalize shared request frequency (including `freq: auto` inference path) before fitting/prediction
- expand N-BEATSx adapter regression tests for non-finite targets and mixed-frequency multi-series requests

## Notes
- Quantiles remain explicit best-effort fallback (mean-only with warning), matching current phase-2 runtime behavior
- Existing runner smoke test remains green

## Validation
- `PYTHONPATH=src pytest -q tests/test_nbeatsx_adapter.py tests/test_nbeatsx_runner.py::test_nbeatsx_runner_forecast_smoke_wires_request_and_response`
- local smoke demo: adapter forecast with mocked dependencies returns deterministic mean and explicit quantile-omission warning
