### PR TITLE
Fix TSFM parity gaps: runtime-family smoke guardrails + local nhits/nbeatsx pulls

### DIFF
--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -41,8 +41,8 @@ Additional docs:
 | `sundial-base-128m` | `sundial` | `thuml/sundial-base-128m` | `main` | `apache-2.0` | No | `runner_sundial` |
 | `toto-open-base-1.0` | `toto` | `Datadog/Toto-Open-Base-1.0` | `main` | `apache-2.0` | No | `runner_toto` |
 | `patchtst` | `patchtst` | `ibm-granite/granite-timeseries-patchtst` | `main` | `apache-2.0` | No | `runner_patchtst` |
-| `nhits` | `nhits` | `cchallu/nhits-air-passengers` | `main` | `apache-2.0` | No | `runner_nhits` |
-| `nbeatsx` | `nbeatsx` | `cchallu/nbeatsx-air-passengers` | `main` | `apache-2.0` | No | `runner_nbeatsx` |
+| `nhits` | `nhits` | `tollama/nhits-runner` (local source manifest) | `main` | `apache-2.0` | No | `runner_nhits` |
+| `nbeatsx` | `nbeatsx` | `tollama/nbeatsx-runner` (local source manifest) | `main` | `apache-2.0` | No | `runner_nbeatsx` |
 
 > [!NOTE]
 > `timesfm` models may take several minutes to compile on the first run. The default timeout has been increased to 5 minutes to accommodate this, but slower machines may require even more time.
@@ -56,6 +56,20 @@ Toto supports target + past numeric covariates; known-future/static/categorical 
 > `nhits` is a **Phase-3 hardened integration**: it is discoverable/pullable and executes canonical single/multi-series forecasts via the dedicated runner family with stricter input/frequency validation. Quantiles are returned on a best-effort basis when backend probabilistic outputs are available; otherwise the runner falls back to mean-only forecasts with explicit warnings. Covariates/static features are still ignored with explicit contract warnings. If dependencies are missing, the runner returns `DEPENDENCY_MISSING` with the install command `python -m pip install -e ".[dev,runner_nhits]"`.
 >
 > `nbeatsx` is a **Phase-3 hardened integration**: it is discoverable/pullable and executes canonical single/multi-series forecasts via the dedicated runner family with stricter input/frequency validation. Quantiles are returned on a best-effort basis when backend probabilistic outputs are available; otherwise the runner falls back to mean-only forecasts with explicit warnings. Covariates/static features are still ignored with warnings. If dependencies are missing, the runner returns `DEPENDENCY_MISSING` with the install command `python -m pip install -e ".[dev,runner_nbeatsx]"`.
+
+## Expected Failure Signatures vs Regressions
+
+Use these signatures when triaging smoke failures:
+
+- **Expected dependency-gated** (environment/setup issue):
+  - HTTP `503` from `/v1/forecast`
+  - detail contains `DEPENDENCY_MISSING`
+  - install hint includes the family extra (for example `runner_patchtst`, `runner_tide`, `runner_nhits`, `runner_nbeatsx`)
+- **Regression** (runtime registration/config issue):
+  - detail contains `runner family '<family>' is not supported`
+  - or pull fails for local-source models (`tide`, `nhits`, `nbeatsx`) that should be manifest-only
+
+For `tide`, `nhits`, and `nbeatsx`, `tollama pull` is manifest-only (`source.type=local`), so pull should succeed without Hugging Face auth/network snapshot fetches.
 
 ## Requirements
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -413,6 +413,7 @@ N-HiTS is integrated for real inference via the dedicated `nhits` runner family.
 - model name: `nhits`
 - runner family: `nhits`
 - install extra: `runner_nhits`
+- pull behavior: registry pull is manifest-only (local source), so `tollama pull nhits` does not require Hugging Face auth/snapshot download
 - current runtime behavior:
   - returns `DEPENDENCY_MISSING` with install guidance when optional dependencies are absent
   - performs runtime NeuralForecast inference for canonical single/multi-series forecast requests
@@ -447,6 +448,7 @@ N-BEATSx is integrated for real inference via the dedicated `nbeatsx` runner fam
 - model name: `nbeatsx`
 - runner family: `nbeatsx`
 - install extra: `runner_nbeatsx`
+- pull behavior: registry pull is manifest-only (local source), so `tollama pull nbeatsx` does not require Hugging Face auth/snapshot download
 - current runtime behavior:
   - returns `DEPENDENCY_MISSING` with install guidance when optional dependencies are absent
   - performs runtime NeuralForecast inference for canonical single/multi-series forecast requests

--- a/model-registry/registry.yaml
+++ b/model-registry/registry.yaml
@@ -212,8 +212,8 @@ models:
   - name: nhits
     family: nhits
     source:
-      type: huggingface
-      repo_id: cchallu/nhits-air-passengers
+      type: local
+      repo_id: tollama/nhits-runner
       revision: main
     license:
       type: apache-2.0
@@ -224,7 +224,7 @@ models:
       support_level: baseline
       install_extra: runner_nhits
       install_command: python -m pip install -e ".[dev,runner_nhits]"
-      notes: N-HiTS runner supports canonical point forecasts (single/multi series) via runtime NeuralForecast inference. Requested quantiles and covariates are currently best-effort limitations and return explicit response warnings.
+      notes: N-HiTS runner supports canonical point forecasts (single/multi series) via runtime NeuralForecast inference. Pull is manifest-only (local source, no Hugging Face snapshot/auth required). Requested quantiles and covariates are currently best-effort limitations and return explicit response warnings.
     capabilities:
       past_covariates_numeric: false
       past_covariates_categorical: false
@@ -235,8 +235,8 @@ models:
   - name: nbeatsx
     family: nbeatsx
     source:
-      type: huggingface
-      repo_id: cchallu/nbeatsx-air-passengers
+      type: local
+      repo_id: tollama/nbeatsx-runner
       revision: main
     license:
       type: apache-2.0
@@ -247,7 +247,7 @@ models:
       support_level: baseline
       install_extra: runner_nbeatsx
       install_command: python -m pip install -e ".[dev,runner_nbeatsx]"
-      notes: N-BEATSx runner supports canonical single/multi-series forecasts via runtime NeuralForecast inference with stricter input validation. Requested quantiles are best-effort (returned when backend probabilistic outputs are exposed, otherwise omitted with explicit warnings). Covariates and static features are currently ignored with explicit warnings.
+      notes: N-BEATSx runner supports canonical single/multi-series forecasts via runtime NeuralForecast inference with stricter input validation. Pull is manifest-only (local source, no Hugging Face snapshot/auth required). Requested quantiles are best-effort (returned when backend probabilistic outputs are exposed, otherwise omitted with explicit warnings). Covariates and static features are currently ignored with explicit warnings.
     capabilities:
       past_covariates_numeric: false
       past_covariates_categorical: false

--- a/src/tollama/runners/nbeatsx_runner/adapter.py
+++ b/src/tollama/runners/nbeatsx_runner/adapter.py
@@ -14,7 +14,7 @@ from .errors import AdapterInputError, DependencyMissingError, UnsupportedModelE
 
 _NBEATSX_MODELS: dict[str, dict[str, Any]] = {
     "nbeatsx": {
-        "repo_id": "cchallu/nbeatsx-air-passengers",
+        "repo_id": "tollama/nbeatsx-runner",
         "revision": "main",
         "implementation": "nbeatsx",
     },

--- a/src/tollama/runners/nhits_runner/adapter.py
+++ b/src/tollama/runners/nhits_runner/adapter.py
@@ -20,7 +20,7 @@ from .errors import (
 
 _NHITS_MODELS: dict[str, dict[str, Any]] = {
     "nhits": {
-        "repo_id": "cchallu/nhits-air-passengers",
+        "repo_id": "tollama/nhits-runner",
         "revision": "main",
         "implementation": "nhits",
     },

--- a/tests/test_nbeatsx_runner.py
+++ b/tests/test_nbeatsx_runner.py
@@ -114,7 +114,7 @@ def test_nbeatsx_runner_forecast_smoke_wires_request_and_response() -> None:
     adapter = _CapturingAdapter()
     params = _valid_forecast_params()
     params["model_local_dir"] = " /tmp/nbeatsx "
-    params["model_source"] = {"repo_id": "cchallu/nbeatsx-air-passengers", "revision": "main"}
+    params["model_source"] = {"repo_id": "tollama/nbeatsx-runner", "revision": "main"}
     params["model_metadata"] = {"implementation": "nbeatsx"}
 
     response = handle_request_line(
@@ -133,7 +133,7 @@ def test_nbeatsx_runner_forecast_smoke_wires_request_and_response() -> None:
     assert call["request"].model == "nbeatsx"
     assert call["request"].horizon == 2
     assert call["model_local_dir"] == "/tmp/nbeatsx"
-    assert call["model_source"] == {"repo_id": "cchallu/nbeatsx-air-passengers", "revision": "main"}
+    assert call["model_source"] == {"repo_id": "tollama/nbeatsx-runner", "revision": "main"}
     assert call["model_metadata"] == {"implementation": "nbeatsx"}
 
 

--- a/tests/test_nhits_runner.py
+++ b/tests/test_nhits_runner.py
@@ -127,7 +127,7 @@ def test_nhits_runner_forecast_smoke_wires_request_and_response() -> None:
     adapter = _CapturingAdapter()
     params = _valid_forecast_params()
     params["model_local_dir"] = " /tmp/nhits "
-    params["model_source"] = {"repo_id": "cchallu/nhits-air-passengers", "revision": "main"}
+    params["model_source"] = {"repo_id": "tollama/nhits-runner", "revision": "main"}
     params["model_metadata"] = {"implementation": "nhits"}
 
     response = handle_request_line(
@@ -146,7 +146,7 @@ def test_nhits_runner_forecast_smoke_wires_request_and_response() -> None:
     assert call["request"].model == "nhits"
     assert call["request"].horizon == 2
     assert call["model_local_dir"] == "/tmp/nhits"
-    assert call["model_source"] == {"repo_id": "cchallu/nhits-air-passengers", "revision": "main"}
+    assert call["model_source"] == {"repo_id": "tollama/nhits-runner", "revision": "main"}
     assert call["model_metadata"] == {"implementation": "nhits"}
 
 

--- a/tests/test_registry_storage.py
+++ b/tests/test_registry_storage.py
@@ -164,7 +164,7 @@ def test_registry_loads_required_model_specs() -> None:
 
     nhits = registry["nhits"]
     assert nhits.family == "nhits"
-    assert nhits.source.repo_id == "cchallu/nhits-air-passengers"
+    assert nhits.source.repo_id == "tollama/nhits-runner"
     assert nhits.source.revision == "main"
     assert nhits.metadata == {
         "implementation": "nhits",
@@ -174,7 +174,8 @@ def test_registry_loads_required_model_specs() -> None:
         "install_command": 'python -m pip install -e ".[dev,runner_nhits]"',
         "notes": (
             "N-HiTS runner supports canonical point forecasts (single/multi series) "
-            "via runtime NeuralForecast inference. Requested quantiles and covariates "
+            "via runtime NeuralForecast inference. Pull is manifest-only (local source, "
+            "no Hugging Face snapshot/auth required). Requested quantiles and covariates "
             "are currently best-effort limitations and return explicit response "
             "warnings."
         ),
@@ -182,7 +183,7 @@ def test_registry_loads_required_model_specs() -> None:
 
     nbeatsx = registry["nbeatsx"]
     assert nbeatsx.family == "nbeatsx"
-    assert nbeatsx.source.repo_id == "cchallu/nbeatsx-air-passengers"
+    assert nbeatsx.source.repo_id == "tollama/nbeatsx-runner"
     assert nbeatsx.source.revision == "main"
     assert nbeatsx.metadata == {
         "implementation": "nbeatsx",
@@ -192,7 +193,8 @@ def test_registry_loads_required_model_specs() -> None:
         "install_command": 'python -m pip install -e ".[dev,runner_nbeatsx]"',
         "notes": (
             "N-BEATSx runner supports canonical single/multi-series forecasts via runtime "
-            "NeuralForecast inference with stricter input validation. Requested quantiles "
+            "NeuralForecast inference with stricter input validation. Pull is manifest-only "
+            "(local source, no Hugging Face snapshot/auth required). Requested quantiles "
             "are best-effort (returned when backend probabilistic outputs are exposed, "
             "otherwise omitted with explicit warnings). Covariates and static features are "
             "currently ignored with explicit warnings."

--- a/tests/test_tsfm_parity_smoke.py
+++ b/tests/test_tsfm_parity_smoke.py
@@ -1,0 +1,70 @@
+"""Non-flaky TSFM parity smoke checks for registry+runtime behavior.
+
+Classification labels used by CI:
+- pass
+- expected-dependency-gated
+- regression
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tollama.daemon.app import create_app
+from tollama.daemon.runner_manager import RunnerManager
+
+
+def _request_payload(model: str) -> dict[str, object]:
+    return {
+        "model": model,
+        "horizon": 2,
+        "quantiles": [0.1, 0.9],
+        "series": [
+            {
+                "id": "s1",
+                "freq": "D",
+                "timestamps": ["2025-01-01", "2025-01-02"],
+                "target": [1.0, 2.0],
+            }
+        ],
+        "options": {},
+    }
+
+
+def _classify_forecast_outcome(status_code: int, payload: dict[str, object]) -> str:
+    if status_code == 200:
+        return "pass"
+
+    detail = payload.get("detail")
+    detail_text = str(detail or "")
+    if status_code == 503 and "DEPENDENCY_MISSING" in detail_text:
+        return "expected-dependency-gated"
+    return "regression"
+
+
+def test_runner_family_registration_includes_patchtst_and_tide() -> None:
+    manager = RunnerManager()
+    families = set(manager.list_families())
+    assert {"patchtst", "tide", "nhits", "nbeatsx"}.issubset(families)
+
+
+def test_local_source_pull_and_runtime_smoke_classification(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("TOLLAMA_HOME", str(tmp_path / ".tollama"))
+
+    with TestClient(create_app()) as client:
+        # Local-source pull should be deterministic and network-free.
+        for model in ("tide", "nhits", "nbeatsx"):
+            pull = client.post("/api/pull", json={"model": model, "stream": False})
+            assert pull.status_code == 200, pull.text
+            pull_body = pull.json()
+            assert pull_body["status"] == "success"
+            assert pull_body["digest"] == "local"
+
+            run = client.post("/v1/forecast", json=_request_payload(model))
+            body = run.json()
+            classification = _classify_forecast_outcome(run.status_code, body)
+            assert classification in {"pass", "expected-dependency-gated"}
+
+            detail_text = str(body.get("detail") or "").lower()
+            assert "runner family" not in detail_text
+            assert "not supported" not in detail_text


### PR DESCRIPTION
## Summary\nFixes the remaining TSFM parity gaps tracked in #33 by hardening pull semantics for NHITS/NBEATSx and adding non-flaky CI smoke coverage for runtime-family parity classification.\n\n### What changed\n- Switched registry source for  and  from brittle HF assumptions to explicit integer 10 readonly !=0
integer 10 readonly '#'=0
integer 10 readonly '$'=52285
array readonly '*'=(  )
readonly -=569X
0=/bin/zsh
integer 10 readonly '?'=127
array readonly @=(  )
integer 10 readonly ARGC=0
tied cdpath CDPATH=''
COLORFGBG='7;0'
COLORTERM=truecolor
integer 10 COLUMNS=0
COMMAND_MODE=unix2003
CONDA_CHANGEPS1=no
CONDA_DEFAULT_ENV=base
CONDA_EXE=/opt/anaconda3/bin/conda
CONDA_PREFIX=/opt/anaconda3
CONDA_PROMPT_MODIFIER=''
CONDA_PYTHON_EXE=/opt/anaconda3/bin/python
CONDA_SHLVL=1
CPUTYPE=x86_64
integer 10 EGID=20
integer 10 EUID=501
tied fignore FIGNORE=''
tied fpath FPATH=/usr/local/share/zsh/site-functions:/usr/share/zsh/site-functions:/usr/share/zsh/5.9/functions
integer 10 FUNCNEST=700
integer 10 GID=20
GSETTINGS_SCHEMA_DIR=/opt/anaconda3/share/glib-2.0/schemas
GSETTINGS_SCHEMA_DIR_CONDA_BACKUP=''
HISTCHARS='!^#'
integer 10 readonly HISTCMD=0
integer 10 HISTSIZE=30
HOME=/Users/ychoi
HOMEBREW_NO_INSTALL_CLEANUP=1
HOST=Yongchoels-MacBook-Pro-15.local
IFS=$' \t\n\C-@'
ITERM_PROFILE=Default
ITERM_SESSION_ID=w0t3p0:657E80F8-8C5F-4D04-BEFD-D39B4952A137
KEYBOARD_HACK=''
integer KEYTIMEOUT=40
LANG=en_US.UTF-8
LC_TERMINAL=iTerm2
LC_TERMINAL_VERSION=3.6.8
LESS=-R
integer 10 readonly LINENO=1
integer 10 LINES=0
integer LISTMAX=100
LOGNAME=ychoi
LSCOLORS=Gxfxcxdxbxegedabagacad
LS_COLORS='di=1;36:ln=35:so=32:pi=33:ex=31:bd=34;46:cd=34;43:su=30;41:sg=30;46:tw=30;42:ow=30;43'
MACHTYPE=x86_64
integer MAILCHECK=60
tied mailpath MAILPATH=''
tied manpath MANPATH=''
tied module_path MODULE_PATH=/usr/lib/zsh/5.9
NODE_NO_WARNINGS=1
NULLCMD=cat
NVM_BIN=/Users/ychoi/.nvm/versions/node/v22.22.0/bin
NVM_CD_FLAGS=-q
NVM_DIR=/Users/ychoi/.nvm
NVM_INC=/Users/ychoi/.nvm/versions/node/v22.22.0/include/node
OLDPWD=/Users/ychoi/Documents/GitHub/tollama
OPENCLAW_GATEWAY_PORT=18789
OPENCLAW_NODE_OPTIONS_READY=1
OPENCLAW_PATH_BOOTSTRAPPED=1
OPENCLAW_SHELL=exec
OPTARG=''
integer 10 OPTIND=1
OSTYPE=darwin24.0
PAGER=less
tied path PATH='/Users/ychoi/.nvm/versions/node/v22.22.0/bin:/usr/local/bin:/usr/bin:/bin:/opt/anaconda3/bin:/opt/anaconda3/condabin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/System/Cryptexes/App/usr/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools:/Applications/iTerm.app/Contents/Resources/utilities'
integer 10 readonly PPID=84850
PROMPT=''
PROMPT2=''
PROMPT3='?# '
PROMPT4='+%N:%i> '
PROMPT_EOL_MARK=''
PS1=''
PS2=''
PS3='?# '
PS4='+%N:%i> '
tied psvar PSVAR=''
PWD=/Users/ychoi/Documents/GitHub/tollama
integer 10 RANDOM=29386
READNULLCMD=more
integer 10 SAVEHIST=0
integer 10 SECONDS=0
SHELL=/bin/zsh
integer 10 SHLVL=2
SPROMPT='zsh: correct '\''%R'\'' to '\''%r'\'' [nyae]? '
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.19mYE1ebkh/Listeners
TERM=xterm-256color
TERMINFO_DIRS=/Applications/iTerm.app/Contents/Resources/terminfo:/usr/share/terminfo
TERM_FEATURES=T3LrMSc7UUw9Ts3BFGsSyHNoSxFP
TERM_PROGRAM=iTerm.app
TERM_PROGRAM_VERSION=3.6.8
TERM_SESSION_ID=w0t3p0:657E80F8-8C5F-4D04-BEFD-D39B4952A137
TIMEFMT='%J  %U user %S system %P cpu %*E total'
TMPDIR=/var/folders/g2/lm7m2b_x6hx_czx9mxv0qnch0000gn/T/
TMPPREFIX=/tmp/zsh
integer 10 TRY_BLOCK_ERROR=-1
integer 10 TRY_BLOCK_INTERRUPT=-1
TTY=''
integer 10 readonly TTYIDLE=-1
integer 10 UID=501
USER=ychoi
USERNAME=ychoi
VENDOR=apple
VIRTUAL_ENV_DISABLE_PROMPT=12
undefined WATCH
WORDCHARS='*?_-.[]~=/&;!#$%^(){}<>'
XPC_FLAGS=0x0
XPC_SERVICE_NAME=0
ZSH=/Users/ychoi/.oh-my-zsh
ZSH_ARGZERO=/bin/zsh
readonly tied zsh_eval_context ZSH_EVAL_CONTEXT=cmdarg:cmdsubst
ZSH_EXECUTION_STRING='gh pr create --base main --head fix/issue-33-tsfm-parity --title "Fix TSFM parity gaps: runtime-family smoke guardrails + local nhits/nbeatsx pulls" --body "## Summary\nFixes the remaining TSFM parity gaps tracked in #33 by hardening pull semantics for NHITS/NBEATSx and adding non-flaky CI smoke coverage for runtime-family parity classification.\n\n### What changed\n- Switched registry source for `nhits` and `nbeatsx` from brittle HF assumptions to explicit `local` source semantics:\n  - `nhits` -> `source.type=local`, `repo_id=tollama/nhits-runner`\n  - `nbeatsx` -> `source.type=local`, `repo_id=tollama/nbeatsx-runner`\n- Updated runner adapter default runtime metadata repo IDs to match new registry semantics.\n- Added CI-safe parity smoke tests (`tests/test_tsfm_parity_smoke.py`) that:\n  - assert runtime family registration includes `patchtst` and `tide` (plus `nhits`, `nbeatsx`)\n  - execute local-source pull + forecast smoke for `tide`, `nhits`, `nbeatsx`\n  - classify outcomes as `pass` / `expected-dependency-gated` / `regression`\n  - treat `runner family ... not supported` as regression signature\n- Updated docs (`docs/how-to-run.md`, `docs/models.md`) to clarify:\n  - local-source manifest-only pull behavior for `nhits`/`nbeatsx`\n  - expected dependency-gated failures vs regression signatures\n- Updated regression tests for registry source metadata and runner wiring expectations.\n\n## Why\n- Removes non-deterministic pull failures caused by private/gated HF repo assumptions for NHITS/NBEATSx.\n- Adds explicit guardrails to prevent recurrence of runtime family availability regressions for patchtst/tide.\n- Provides predictable CI signal that distinguishes setup-gated dependency failures from real regressions.\n\n## Validation\n- `pytest -q tests/test_registry_storage.py tests/test_nhits_runner.py tests/test_nbeatsx_runner.py tests/test_tsfm_parity_smoke.py tests/test_runner_manager.py`\n- Manual smoke matrix:\n  - `tollama pull/run lag-llama patchtst tide nhits nbeatsx`\n  - Observed: pull succeeds for all; `tide`/`nhits`/`nbeatsx` pulls are local (`digest=local`); run outcomes are dependency-gated (`DEPENDENCY_MISSING`) and no `runner family ... not supported` regressions.\n\nCloses #33"'
ZSH_NAME=zsh
ZSH_PATCHLEVEL=zsh-5.9-0-g73d3173
integer 10 readonly ZSH_SUBSHELL=1
ZSH_VERSION=5.9
_=local
_CE_CONDA=''
_CE_M=''
__CFBundleIdentifier=com.googlecode.iterm2
__CF_USER_TEXT_ENCODING=0x1F5:0:0
undefined aliases
array argv=(  )
undefined builtins
array tied CDPATH cdpath=(  )
undefined commands
undefined dirstack
undefined dis_aliases
undefined dis_builtins
undefined dis_functions
undefined dis_functions_source
undefined dis_galiases
undefined dis_patchars
undefined dis_reswords
undefined dis_saliases
array tied FIGNORE fignore=(  )
array tied FPATH fpath=( /usr/local/share/zsh/site-functions /usr/share/zsh/site-functions /usr/share/zsh/5.9/functions )
undefined funcfiletrace
undefined funcsourcetrace
undefined funcstack
undefined functions
undefined functions_source
undefined functrace
undefined galiases
histchars='!^#'
undefined history
undefined historywords
undefined jobdirs
undefined jobstates
undefined jobtexts
undefined keymaps
array tied MAILPATH mailpath=(  )
array tied MANPATH manpath=(  )
array tied MODULE_PATH module_path=( /usr/lib/zsh/5.9 )
undefined modules
undefined nameddirs
undefined options
undefined parameters
undefined patchars
array tied PATH path=( /Users/ychoi/.nvm/versions/node/v22.22.0/bin /usr/local/bin /usr/bin /bin /opt/anaconda3/bin /opt/anaconda3/condabin /Library/Frameworks/Python.framework/Versions/3.11/bin /System/Cryptexes/App/usr/bin /usr/sbin /sbin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin /Library/Apple/usr/bin /usr/local/share/dotnet '~/.dotnet/tools' /Applications/iTerm.app/Contents/Resources/utilities )
array pipestatus=(  )
prompt=''
array tied PSVAR psvar=(  )
undefined reswords
undefined saliases
array signals=( EXIT HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM URG STOP TSTP CONT CHLD TTIN TTOU IO XCPU XFSZ VTALRM PROF WINCH INFO USR1 USR2 ZERR DEBUG )
integer 10 readonly status=127
undefined termcap
undefined terminfo
undefined userdirs
undefined usergroups
undefined watch
undefined widgets
array readonly tied ZSH_EVAL_CONTEXT zsh_eval_context=( cmdarg cmdsubst )
undefined zsh_scheduled_events source semantics:\n  -  -> , \n  -  -> , \n- Updated runner adapter default runtime metadata repo IDs to match new registry semantics.\n- Added CI-safe parity smoke tests () that:\n  - assert runtime family registration includes  and  (plus , )\n  - execute local-source pull + forecast smoke for , , \n  - classify outcomes as  /  / \n  - treat  as regression signature\n- Updated docs (, ) to clarify:\n  - local-source manifest-only pull behavior for /\n  - expected dependency-gated failures vs regression signatures\n- Updated regression tests for registry source metadata and runner wiring expectations.\n\n## Why\n- Removes non-deterministic pull failures caused by private/gated HF repo assumptions for NHITS/NBEATSx.\n- Adds explicit guardrails to prevent recurrence of runtime family availability regressions for patchtst/tide.\n- Provides predictable CI signal that distinguishes setup-gated dependency failures from real regressions.\n\n## Validation\n- ...................................                                      [100%]\n- Manual smoke matrix:\n  - \n  - Observed: pull succeeds for all; // pulls are local (); run outcomes are dependency-gated () and no  regressions.\n\nCloses #33