### PR TITLE
feat: cross-model TSFM benchmark protocol and routing defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,23 @@ Compare SDK ergonomics and time-to-first-forecast versus raw client calls:
 PYTHONPATH=src python benchmarks/tollama_vs_raw.py --model mock --iterations 3 --warmup 1
 ```
 
+Run cross-model TSFM benchmark + routing default recommendation
+(Lag-Llama, PatchTST, TiDE, N-HiTS, N-BEATSx):
+
+```bash
+# protocol/report template (no daemon required)
+PYTHONPATH=src python benchmarks/cross_model_tsfm.py \
+  --template-only \
+  --output-dir benchmarks/reports/cross_model_baseline
+
+# full benchmark run
+PYTHONPATH=src python benchmarks/cross_model_tsfm.py \
+  --base-url http://127.0.0.1:11435 \
+  --output-dir artifacts/benchmarks/cross_model
+```
+
+See `docs/tsfm-routing-defaults.md` for benchmark protocol and routing-policy interpretation.
+
 ## Docker
 
 Build and run:

--- a/benchmarks/cross_model_tsfm.py
+++ b/benchmarks/cross_model_tsfm.py
@@ -1,0 +1,492 @@
+"""Cross-model TSFM benchmark for quality/latency routing defaults.
+
+This benchmark compares five target models in Tollama:
+- lag-llama
+- patchtst
+- tide
+- nhits
+- nbeatsx
+
+Protocol is deterministic and reproducible by default:
+- synthetic benchmark datasets generated from a fixed seed
+- fixed train/test split by horizon
+- repeated non-stream forecast calls for latency profiling
+- standardized quality metrics and markdown/json artifacts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from tollama.client import TollamaClient
+from tollama.client.exceptions import TollamaClientError
+
+MODELS = ["lag-llama", "patchtst", "tide", "nhits", "nbeatsx"]
+DEFAULT_DATASETS = ["seasonal_daily", "trend_weekly", "intermittent_daily"]
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkSeries:
+    dataset: str
+    freq: str
+    context: list[float]
+    actuals: list[float]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelRun:
+    model: str
+    dataset: str
+    status: str
+    error: str | None
+    quality: dict[str, float]
+    latency_ms: dict[str, float]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Cross-model TSFM benchmark + routing defaults")
+    parser.add_argument("--base-url", default="http://127.0.0.1:11435")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--models", default=",".join(MODELS))
+    parser.add_argument("--datasets", default=",".join(DEFAULT_DATASETS))
+    parser.add_argument("--context-length", type=int, default=96)
+    parser.add_argument("--horizon", type=int, default=24)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", default="artifacts/benchmarks/cross_model")
+    parser.add_argument(
+        "--skip-pull",
+        action="store_true",
+        help="Skip pull preflight (useful when models are already installed)",
+    )
+    parser.add_argument(
+        "--template-only",
+        action="store_true",
+        help="Write protocol/report template without contacting daemon",
+    )
+    return parser.parse_args(argv)
+
+
+def _generate_series(
+    *, dataset: str, context_length: int, horizon: int, seed: int
+) -> BenchmarkSeries:
+    total = context_length + horizon
+    if dataset == "seasonal_daily":
+        values = [
+            50.0
+            + 0.15 * i
+            + 10.0 * math.sin((2.0 * math.pi * i) / 7.0)
+            + 2.0 * math.cos((2.0 * math.pi * i) / 30.0)
+            for i in range(total)
+        ]
+        freq = "D"
+    elif dataset == "trend_weekly":
+        values = [30.0 + 0.6 * i + 3.0 * math.sin((2.0 * math.pi * i) / 12.0) for i in range(total)]
+        freq = "W"
+    elif dataset == "intermittent_daily":
+        # Deterministic pseudo-intermittent pattern (no randomness dependency in output shape).
+        values = []
+        for i in range(total):
+            base = 12.0 + 0.05 * i
+            burst = 14.0 if (i + seed) % 17 in {0, 1, 2} else 0.0
+            valley = -6.0 if (i + seed) % 19 == 0 else 0.0
+            values.append(max(0.0, base + burst + valley))
+        freq = "D"
+    else:
+        raise ValueError(f"unsupported dataset: {dataset}")
+
+    return BenchmarkSeries(
+        dataset=dataset,
+        freq=freq,
+        context=[float(v) for v in values[:context_length]],
+        actuals=[float(v) for v in values[context_length:]],
+    )
+
+
+def _mae(actual: list[float], pred: list[float]) -> float:
+    return statistics.fmean(abs(a - p) for a, p in zip(actual, pred))
+
+
+def _rmse(actual: list[float], pred: list[float]) -> float:
+    return math.sqrt(statistics.fmean((a - p) ** 2 for a, p in zip(actual, pred)))
+
+
+def _mape(actual: list[float], pred: list[float]) -> float:
+    eps = 1e-9
+    return 100.0 * statistics.fmean(abs((a - p) / max(abs(a), eps)) for a, p in zip(actual, pred))
+
+
+def _smape(actual: list[float], pred: list[float]) -> float:
+    eps = 1e-9
+    return 100.0 * statistics.fmean(
+        (2.0 * abs(a - p)) / max(abs(a) + abs(p), eps) for a, p in zip(actual, pred)
+    )
+
+
+def _mase(
+    actual: list[float], pred: list[float], insample: list[float], seasonality: int = 1
+) -> float:
+    if len(insample) <= seasonality:
+        return float("nan")
+    naive_errors = [
+        abs(insample[i] - insample[i - seasonality]) for i in range(seasonality, len(insample))
+    ]
+    denom = statistics.fmean(naive_errors) if naive_errors else 0.0
+    if denom <= 1e-12:
+        return float("nan")
+    return _mae(actual, pred) / denom
+
+
+def _extract_mean_forecast(payload: dict[str, Any], expected_horizon: int) -> list[float]:
+    forecasts = payload.get("forecasts")
+    if not isinstance(forecasts, list) or not forecasts:
+        raise ValueError("response missing forecasts[]")
+    first = forecasts[0]
+    if not isinstance(first, dict):
+        raise ValueError("response forecasts[0] is not object")
+    mean = first.get("mean")
+    if not isinstance(mean, list):
+        raise ValueError("response forecasts[0].mean missing")
+    values = [float(v) for v in mean]
+    if len(values) < expected_horizon:
+        raise ValueError(
+            f"forecast shorter than horizon: len={len(values)} horizon={expected_horizon}"
+        )
+    return values[:expected_horizon]
+
+
+def _score_run(*, quality: dict[str, float], p50_ms: float) -> tuple[float, float]:
+    # Lower-is-better unified quality score + latency cost.
+    quality_score = quality["smape"] + 10.0 * quality["mase"]
+    latency_score = p50_ms / 1000.0
+    return quality_score, latency_score
+
+
+def _recommend_routing(runs: list[ModelRun]) -> dict[str, Any]:
+    successful = [run for run in runs if run.status == "pass"]
+    if not successful:
+        return {
+            "default": None,
+            "fast_path": None,
+            "high_accuracy": None,
+            "policy": "no successful benchmark runs",
+            "caveats": ["all model runs failed; keep existing routing unchanged"],
+        }
+
+    per_model: dict[str, dict[str, list[float]]] = {}
+    for run in successful:
+        bucket = per_model.setdefault(run.model, {"quality": [], "latency": []})
+        quality_score, latency_score = _score_run(
+            quality=run.quality,
+            p50_ms=float(run.latency_ms["p50"]),
+        )
+        bucket["quality"].append(quality_score)
+        bucket["latency"].append(latency_score)
+
+    ranked = []
+    for model, scores in per_model.items():
+        ranked.append(
+            {
+                "model": model,
+                "quality_score": statistics.fmean(scores["quality"]),
+                "latency_score": statistics.fmean(scores["latency"]),
+            }
+        )
+
+    quality_sorted = sorted(
+        ranked, key=lambda item: (item["quality_score"], item["latency_score"], item["model"])
+    )
+    latency_sorted = sorted(
+        ranked, key=lambda item: (item["latency_score"], item["quality_score"], item["model"])
+    )
+
+    # Balanced objective with stronger quality weight.
+    balanced_sorted = sorted(
+        ranked,
+        key=lambda item: (0.7 * item["quality_score"] + 0.3 * item["latency_score"], item["model"]),
+    )
+
+    default_model = balanced_sorted[0]["model"]
+    fast_model = latency_sorted[0]["model"]
+    accurate_model = quality_sorted[0]["model"]
+
+    return {
+        "default": default_model,
+        "fast_path": fast_model,
+        "high_accuracy": accurate_model,
+        "policy": (
+            "Use default for general workloads; route latency-sensitive requests to fast_path; "
+            "route mission-critical accuracy requests to high_accuracy."
+        ),
+        "ranking": balanced_sorted,
+        "caveats": [
+            (
+                "Benchmark uses deterministic synthetic datasets by default; "
+                "validate against production data."
+            ),
+            "Latency depends on hardware/runtime bootstrap state and may shift after warm-up.",
+        ],
+    }
+
+
+def _run_single(
+    *,
+    client: TollamaClient,
+    model: str,
+    series: BenchmarkSeries,
+    horizon: int,
+    repeats: int,
+) -> ModelRun:
+    payload = {
+        "model": model,
+        "horizon": horizon,
+        "series": [
+            {
+                "id": f"{series.dataset}-s1",
+                "freq": series.freq,
+                "timestamps": [str(i + 1) for i in range(len(series.context))],
+                "target": series.context,
+            }
+        ],
+        "options": {},
+    }
+
+    latencies: list[float] = []
+    latest_payload: dict[str, Any] | None = None
+
+    try:
+        for _ in range(max(1, repeats)):
+            started = perf_counter()
+            response = client.forecast(payload, stream=False)
+            latencies.append((perf_counter() - started) * 1000.0)
+            if not isinstance(response, dict):
+                raise ValueError("forecast response is not object")
+            latest_payload = response
+
+        assert latest_payload is not None
+        prediction = _extract_mean_forecast(latest_payload, expected_horizon=horizon)
+
+        quality = {
+            "mae": round(_mae(series.actuals, prediction), 6),
+            "rmse": round(_rmse(series.actuals, prediction), 6),
+            "mape": round(_mape(series.actuals, prediction), 6),
+            "smape": round(_smape(series.actuals, prediction), 6),
+            "mase": round(_mase(series.actuals, prediction, series.context, seasonality=1), 6),
+        }
+        latency = {
+            "p50": round(float(statistics.median(latencies)), 3),
+            "mean": round(float(statistics.fmean(latencies)), 3),
+            "p95": round(float(_percentile(latencies, 95.0)), 3),
+        }
+        return ModelRun(
+            model=model,
+            dataset=series.dataset,
+            status="pass",
+            error=None,
+            quality=quality,
+            latency_ms=latency,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ModelRun(
+            model=model,
+            dataset=series.dataset,
+            status="fail",
+            error=str(exc),
+            quality={},
+            latency_ms={},
+        )
+
+
+def _percentile(values: list[float], q: float) -> float:
+    if not values:
+        return float("nan")
+    data = sorted(float(v) for v in values)
+    if len(data) == 1:
+        return data[0]
+    position = (len(data) - 1) * (q / 100.0)
+    lower = int(math.floor(position))
+    upper = int(math.ceil(position))
+    if lower == upper:
+        return data[lower]
+    weight = position - lower
+    return data[lower] * (1.0 - weight) + data[upper] * weight
+
+
+def _markdown_report(payload: dict[str, Any]) -> str:
+    protocol = payload["protocol"]
+    lines = [
+        "# Cross-Model TSFM Benchmark Report",
+        "",
+        f"- run_id: `{payload['run_id']}`",
+        f"- generated_at: `{payload['generated_at']}`",
+        f"- base_url: `{protocol['base_url']}`",
+        f"- models: {', '.join(protocol['models'])}",
+        f"- datasets: {', '.join(protocol['datasets'])}",
+        f"- split: context={protocol['context_length']}, horizon={protocol['horizon']}",
+        f"- repeats per run: {protocol['repeats']}",
+        "",
+        "## Per-run results",
+        "",
+        "| model | dataset | status | sMAPE | MASE | p50 latency (ms) | p95 latency (ms) | error |",
+        "|---|---|---|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["runs"]:
+        q = row.get("quality", {})
+        latency = row.get("latency_ms", {})
+        row_template = (
+            "| {model} | {dataset} | {status} | {smape} | {mase} | "
+            "{p50} | {p95} | {error} |"
+        )
+        lines.append(
+            row_template.format(
+                model=row["model"],
+                dataset=row["dataset"],
+                status=row["status"],
+                smape=q.get("smape", "-"),
+                mase=q.get("mase", "-"),
+                p50=latency.get("p50", "-"),
+                p95=latency.get("p95", "-"),
+                error=(row.get("error") or "").replace("|", "/"),
+            )
+        )
+
+    routing = payload["routing_recommendation"]
+    lines.extend(
+        [
+            "",
+            "## Routing recommendation",
+            "",
+            f"- default: `{routing.get('default')}`",
+            f"- fast_path: `{routing.get('fast_path')}`",
+            f"- high_accuracy: `{routing.get('high_accuracy')}`",
+            f"- policy: {routing.get('policy')}",
+            "",
+            "### Caveats",
+        ]
+    )
+    lines.extend(f"- {item}" for item in routing.get("caveats", []))
+    return "\n".join(lines) + "\n"
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    models = [item.strip() for item in args.models.split(",") if item.strip()]
+    datasets = [item.strip() for item in args.datasets.split(",") if item.strip()]
+    run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+    protocol = {
+        "base_url": args.base_url,
+        "models": models,
+        "datasets": datasets,
+        "context_length": int(args.context_length),
+        "horizon": int(args.horizon),
+        "metrics": ["mae", "rmse", "mape", "smape", "mase", "latency_p50", "latency_p95"],
+        "split": "last horizon points as holdout; remaining as context",
+        "repeats": int(args.repeats),
+        "seed": int(args.seed),
+    }
+
+    if args.template_only:
+        template_payload = {
+            "run_id": run_id,
+            "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+            "protocol": protocol,
+            "runs": [],
+            "routing_recommendation": {
+                "default": "<to-be-filled>",
+                "fast_path": "<to-be-filled>",
+                "high_accuracy": "<to-be-filled>",
+                "policy": "Populate after benchmark execution.",
+                "caveats": [
+                    "Template-only run. No daemon/model execution performed.",
+                    "Fill with actual results after running with a live tollama daemon.",
+                ],
+            },
+        }
+        _write(
+            out_dir / "report_template.json", json.dumps(template_payload, indent=2, sort_keys=True)
+        )
+        _write(out_dir / "report_template.md", _markdown_report(template_payload))
+        print(f"template artifacts written: {out_dir}")
+        return 0
+
+    client = TollamaClient(base_url=args.base_url, timeout=float(args.timeout))
+    try:
+        _ = client.health()
+    except TollamaClientError as exc:
+        print(f"daemon unreachable: {exc}")
+        return 2
+
+    if not args.skip_pull:
+        for model in models:
+            try:
+                _ = client.pull_model(name=model, stream=False, accept_license=True)
+            except TollamaClientError as exc:
+                print(f"warning: pull failed for {model}: {exc}")
+
+    series_list = [
+        _generate_series(
+            dataset=dataset,
+            context_length=int(args.context_length),
+            horizon=int(args.horizon),
+            seed=int(args.seed),
+        )
+        for dataset in datasets
+    ]
+
+    runs: list[ModelRun] = []
+    for model in models:
+        for series in series_list:
+            runs.append(
+                _run_single(
+                    client=client,
+                    model=model,
+                    series=series,
+                    horizon=int(args.horizon),
+                    repeats=int(args.repeats),
+                )
+            )
+
+    routing = _recommend_routing(runs)
+    payload = {
+        "run_id": run_id,
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        "protocol": protocol,
+        "runs": [
+            {
+                "model": run.model,
+                "dataset": run.dataset,
+                "status": run.status,
+                "error": run.error,
+                "quality": run.quality,
+                "latency_ms": run.latency_ms,
+            }
+            for run in runs
+        ],
+        "routing_recommendation": routing,
+    }
+
+    _write(out_dir / "result.json", json.dumps(payload, indent=2, sort_keys=True))
+    _write(out_dir / "result.md", _markdown_report(payload))
+    print(f"benchmark artifacts written: {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/reports/cross_model_baseline/report_template.json
+++ b/benchmarks/reports/cross_model_baseline/report_template.json
@@ -1,0 +1,44 @@
+{
+  "generated_at": "2026-03-06T14:10:42+00:00",
+  "protocol": {
+    "base_url": "http://127.0.0.1:11435",
+    "context_length": 96,
+    "datasets": [
+      "seasonal_daily",
+      "trend_weekly",
+      "intermittent_daily"
+    ],
+    "horizon": 24,
+    "metrics": [
+      "mae",
+      "rmse",
+      "mape",
+      "smape",
+      "mase",
+      "latency_p50",
+      "latency_p95"
+    ],
+    "models": [
+      "lag-llama",
+      "patchtst",
+      "tide",
+      "nhits",
+      "nbeatsx"
+    ],
+    "repeats": 3,
+    "seed": 42,
+    "split": "last horizon points as holdout; remaining as context"
+  },
+  "routing_recommendation": {
+    "caveats": [
+      "Template-only run. No daemon/model execution performed.",
+      "Fill with actual results after running with a live tollama daemon."
+    ],
+    "default": "<to-be-filled>",
+    "fast_path": "<to-be-filled>",
+    "high_accuracy": "<to-be-filled>",
+    "policy": "Populate after benchmark execution."
+  },
+  "run_id": "20260306T141042Z",
+  "runs": []
+}

--- a/benchmarks/reports/cross_model_baseline/report_template.md
+++ b/benchmarks/reports/cross_model_baseline/report_template.md
@@ -1,0 +1,25 @@
+# Cross-Model TSFM Benchmark Report
+
+- run_id: `20260306T141042Z`
+- generated_at: `2026-03-06T14:10:42+00:00`
+- base_url: `http://127.0.0.1:11435`
+- models: lag-llama, patchtst, tide, nhits, nbeatsx
+- datasets: seasonal_daily, trend_weekly, intermittent_daily
+- split: context=96, horizon=24
+- repeats per run: 3
+
+## Per-run results
+
+| model | dataset | status | sMAPE | MASE | p50 latency (ms) | p95 latency (ms) | error |
+|---|---|---|---:|---:|---:|---:|---|
+
+## Routing recommendation
+
+- default: `<to-be-filled>`
+- fast_path: `<to-be-filled>`
+- high_accuracy: `<to-be-filled>`
+- policy: Populate after benchmark execution.
+
+### Caveats
+- Template-only run. No daemon/model execution performed.
+- Fill with actual results after running with a live tollama daemon.

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -740,6 +740,30 @@ and raw client calls:
 PYTHONPATH=src python benchmarks/tollama_vs_raw.py --model mock --iterations 3 --warmup 1
 ```
 
+Cross-model TSFM benchmark + routing-default recommendation (Lag-Llama, PatchTST,
+TiDE, N-HiTS, N-BEATSx):
+
+```bash
+# Template-only protocol/report artifact (works without a running daemon)
+PYTHONPATH=src python benchmarks/cross_model_tsfm.py \
+  --template-only \
+  --output-dir benchmarks/reports/cross_model_baseline
+
+# Full benchmark run against a running daemon
+PYTHONPATH=src python benchmarks/cross_model_tsfm.py \
+  --base-url http://127.0.0.1:11435 \
+  --output-dir artifacts/benchmarks/cross_model
+```
+
+Artifacts:
+
+- `result.json` / `result.md`: per-model per-dataset quality + latency results and
+  a routing recommendation (`default`, `fast_path`, `high_accuracy`)
+- `report_template.json` / `report_template.md`: protocol/report template when
+  execution environment is unavailable
+
+See `docs/tsfm-routing-defaults.md` for protocol details and policy interpretation.
+
 ## Development Checks
 
 ```bash

--- a/docs/tsfm-routing-defaults.md
+++ b/docs/tsfm-routing-defaults.md
@@ -1,0 +1,86 @@
+# TSFM Cross-Model Benchmark Protocol & Routing Defaults
+
+This document defines a reproducible benchmark protocol for five TSFM models and
+how to derive routing defaults from benchmark outcomes.
+
+## Scope
+
+Compared models:
+
+- `lag-llama`
+- `patchtst`
+- `tide`
+- `nhits`
+- `nbeatsx`
+
+## Standard protocol
+
+- **Datasets** (deterministic synthetic):
+  - `seasonal_daily` (`freq=D`)
+  - `trend_weekly` (`freq=W`)
+  - `intermittent_daily` (`freq=D`)
+- **Split**: fixed holdout = last `horizon` points, training context = preceding
+  `context_length` points.
+- **Default split params**:
+  - `context_length=96`
+  - `horizon=24`
+- **Latency sampling**: repeated non-stream calls (`repeats=3` by default).
+- **Metrics**:
+  - Accuracy: `MAE`, `RMSE`, `MAPE`, `sMAPE`, `MASE`
+  - Performance: latency `p50`, `mean`, `p95` (ms)
+- **Reporting format**:
+  - machine-readable: `result.json`
+  - human-readable: `result.md`
+  - environment-limited fallback: `report_template.json`, `report_template.md`
+
+## Run commands
+
+```bash
+# 1) Template-only (no daemon needed)
+PYTHONPATH=src python benchmarks/cross_model_tsfm.py \
+  --template-only \
+  --output-dir benchmarks/reports/cross_model_baseline
+
+# 2) Full benchmark run (daemon required)
+PYTHONPATH=src python benchmarks/cross_model_tsfm.py \
+  --base-url http://127.0.0.1:11435 \
+  --output-dir artifacts/benchmarks/cross_model
+```
+
+## Routing default policy
+
+The benchmark derives a policy with three routing targets:
+
+- **default**: balanced quality/latency objective
+- **fast_path**: minimum latency objective
+- **high_accuracy**: minimum error objective
+
+Current scoring is intentionally simple and transparent:
+
+- quality score = `sMAPE + 10 * MASE` (lower is better)
+- latency score = `p50_ms / 1000`
+- balanced ranking = `0.7 * quality_score + 0.3 * latency_score`
+
+Use policy like this:
+
+- standard requests → `default`
+- interactive/low-latency requests → `fast_path`
+- backtesting/critical forecasting requests → `high_accuracy`
+
+## Caveats
+
+- Synthetic data is reproducible and useful for regressions, but final routing
+  defaults should be validated on production-like datasets.
+- First-run latency can be inflated by model/runtime bootstrap and cache misses.
+- If model dependencies are missing, use template artifacts and mark recommendation
+  as provisional.
+
+## Baseline artifact in repository
+
+A baseline template artifact is committed at:
+
+- `benchmarks/reports/cross_model_baseline/report_template.json`
+- `benchmarks/reports/cross_model_baseline/report_template.md`
+
+These artifacts document protocol and reporting schema even when benchmark
+execution is unavailable in CI or local environments.

--- a/tests/test_cross_model_benchmark.py
+++ b/tests/test_cross_model_benchmark.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "benchmarks" / "cross_model_tsfm.py"
+_MODULE_SPEC = spec_from_file_location("benchmarks_cross_model_tsfm", _MODULE_PATH)
+assert _MODULE_SPEC is not None and _MODULE_SPEC.loader is not None
+_MODULE = module_from_spec(_MODULE_SPEC)
+sys.modules[_MODULE_SPEC.name] = _MODULE
+_MODULE_SPEC.loader.exec_module(_MODULE)
+
+ModelRun = _MODULE.ModelRun
+_extract_mean_forecast = _MODULE._extract_mean_forecast
+_mase = _MODULE._mase
+_recommend_routing = _MODULE._recommend_routing
+
+
+def test_extract_mean_forecast_truncates_to_horizon() -> None:
+    payload = {"forecasts": [{"mean": [1.0, 2.0, 3.0, 4.0]}]}
+    result = _extract_mean_forecast(payload, expected_horizon=3)
+    assert result == [1.0, 2.0, 3.0]
+
+
+def test_mase_returns_nan_when_denom_is_zero() -> None:
+    actual = [1.0, 1.0]
+    pred = [1.0, 1.0]
+    insample = [2.0, 2.0, 2.0]
+    value = _mase(actual, pred, insample, seasonality=1)
+    assert value != value  # NaN check
+
+
+def test_recommend_routing_prefers_quality_vs_latency() -> None:
+    runs = [
+        ModelRun(
+            model="patchtst",
+            dataset="d1",
+            status="pass",
+            error=None,
+            quality={"smape": 10.0, "mase": 1.0},
+            latency_ms={"p50": 140.0, "mean": 150.0, "p95": 190.0},
+        ),
+        ModelRun(
+            model="nhits",
+            dataset="d1",
+            status="pass",
+            error=None,
+            quality={"smape": 12.0, "mase": 1.2},
+            latency_ms={"p50": 80.0, "mean": 90.0, "p95": 120.0},
+        ),
+        ModelRun(
+            model="nbeatsx",
+            dataset="d1",
+            status="pass",
+            error=None,
+            quality={"smape": 7.0, "mase": 0.8},
+            latency_ms={"p50": 250.0, "mean": 260.0, "p95": 310.0},
+        ),
+    ]
+
+    recommendation = _recommend_routing(runs)
+    assert recommendation["default"] == "nbeatsx"
+    assert recommendation["fast_path"] == "nhits"
+    assert recommendation["high_accuracy"] == "nbeatsx"


### PR DESCRIPTION
## Summary
- add reproducible cross-model benchmark pipeline for `lag-llama`, `patchtst`, `tide`, `nhits`, `nbeatsx`
- define standardized protocol (datasets/splits/metrics/report format) and document routing-default interpretation
- add in-repo baseline benchmark artifact template with explicit caveats for environment-limited runs
- add lightweight tests for benchmark glue/metrics extraction/routing recommendation

## Details
- new benchmark script: `benchmarks/cross_model_tsfm.py`
- new docs: `docs/tsfm-routing-defaults.md`
- docs updates: `README.md`, `docs/how-to-run.md`
- baseline artifact: `benchmarks/reports/cross_model_baseline/report_template.{json,md}`
- tests: `tests/test_cross_model_benchmark.py`

## Validation
- `PYTHONPATH=src ruff check benchmarks/cross_model_tsfm.py tests/test_cross_model_benchmark.py`
- `PYTHONPATH=src pytest -q tests/test_cross_model_benchmark.py tests/test_benchmark_tollama_vs_raw.py`

Closes #40
