### PR TITLE
feat: integrate benchmark-driven routing defaults into auto-forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,11 @@ tollama config set pull.https_proxy http://proxy:3128
 tollama config set pull.hf_home /mnt/fastcache/hf
 tollama config set pull.offline true
 
+# benchmark-driven routing defaults for auto-forecast
+tollama config set routing.default lag-llama
+tollama config set routing.fast_path nhits
+tollama config set routing.high_accuracy nbeatsx
+
 # no pull flags needed; daemon applies config defaults
 tollama pull chronos2
 ```

--- a/docs/tsfm-routing-defaults.md
+++ b/docs/tsfm-routing-defaults.md
@@ -67,6 +67,30 @@ Use policy like this:
 - interactive/low-latency requests → `fast_path`
 - backtesting/critical forecasting requests → `high_accuracy`
 
+Persist benchmark output into tollama config:
+
+```bash
+tollama config set routing.default lag-llama
+tollama config set routing.fast_path nhits
+tollama config set routing.high_accuracy nbeatsx
+```
+
+Then select routing mode per request (model omitted on purpose):
+
+```bash
+curl -s http://127.0.0.1:11435/api/auto-forecast \
+  -H 'content-type: application/json' \
+  -d '{
+    "horizon": 24,
+    "mode": "fast_path",
+    "series": [{"id":"s1","freq":"D","timestamps":["1","2","3"],"target":[1,2,3]}]
+  }'
+```
+
+If the configured routing model is unavailable or fails, daemon falls back to
+normal auto-selection. Explicit `model` requests still take precedence over
+configured routing defaults.
+
 ## Caveats
 
 - Synthetic data is reproducible and useful for regressions, but final routing

--- a/src/tollama/core/config.py
+++ b/src/tollama/core/config.py
@@ -44,6 +44,16 @@ class AuthConfig(BaseModel):
     api_keys: list[StrictStr] = Field(default_factory=list)
 
 
+class RoutingDefaults(BaseModel):
+    """Optional benchmark-driven model routing defaults."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    default: StrictStr | None = None
+    fast_path: StrictStr | None = None
+    high_accuracy: StrictStr | None = None
+
+
 class TollamaConfig(BaseModel):
     """Top-level persisted tollama config."""
 
@@ -53,6 +63,7 @@ class TollamaConfig(BaseModel):
     pull: PullDefaults = Field(default_factory=PullDefaults)
     daemon: DaemonDefaults = Field(default_factory=DaemonDefaults)
     auth: AuthConfig = Field(default_factory=AuthConfig)
+    routing: RoutingDefaults = Field(default_factory=RoutingDefaults)
 
 
 CONFIG_KEY_DESCRIPTIONS: dict[str, str] = {
@@ -64,6 +75,9 @@ CONFIG_KEY_DESCRIPTIONS: dict[str, str] = {
     "pull.local_files_only": "Use cached artifacts only without forcing full offline mode.",
     "pull.insecure": "Disable TLS verification during pulls (debugging only).",
     "pull.max_workers": "Maximum download worker threads for model pulls.",
+    "routing.default": "Preferred model for balanced default routing mode.",
+    "routing.fast_path": "Preferred model for low-latency routing mode.",
+    "routing.high_accuracy": "Preferred model for high-accuracy routing mode.",
 }
 
 

--- a/src/tollama/core/schemas.py
+++ b/src/tollama/core/schemas.py
@@ -33,6 +33,7 @@ TrendDirection = Literal["up", "down", "flat"]
 ConfidenceLevel = Literal["high", "medium", "low", "unknown"]
 VolatilityChange = Literal["lower", "stable", "higher", "unknown"]
 AutoForecastStrategy = Literal["auto", "fastest", "best_accuracy", "ensemble"]
+RoutingMode = Literal["default", "fast_path", "high_accuracy"]
 EnsembleMethod = Literal["mean", "median"]
 GenerateMethod = Literal["statistical"]
 ProgressiveStageStrategy = Literal["fastest", "best_accuracy", "explicit"]
@@ -277,6 +278,7 @@ class AutoForecastRequest(CanonicalModel):
     model: NonEmptyStr | None = None
     allow_fallback: StrictBool = False
     strategy: AutoForecastStrategy = "auto"
+    mode: RoutingMode = "default"
     ensemble_top_k: StrictInt = Field(default=3, ge=2, le=8)
     ensemble_method: EnsembleMethod = "mean"
     horizon: PositiveInt

--- a/src/tollama/daemon/app.py
+++ b/src/tollama/daemon/app.py
@@ -2094,6 +2094,20 @@ def _record_usage(
         return
 
 
+def _configured_routing_model_for_mode(*, app: FastAPI, mode: str) -> str | None:
+    try:
+        config: TollamaConfig = app.state.config_provider.get()
+    except ConfigFileError:
+        return None
+
+    routing_defaults = config.routing
+    if mode == "fast_path":
+        return routing_defaults.fast_path
+    if mode == "high_accuracy":
+        return routing_defaults.high_accuracy
+    return routing_defaults.default
+
+
 def _execute_auto_forecast(
     app: FastAPI,
     *,
@@ -2117,6 +2131,52 @@ def _execute_auto_forecast(
     fallback_used = False
     fallback_rationale: list[str] = []
     blocked_models: set[str] = set()
+
+    configured_mode_model = _configured_routing_model_for_mode(app=app, mode=payload.mode)
+    if payload.model is None and configured_mode_model is not None:
+        configured_manifest = installed_by_name.get(configured_mode_model)
+        if configured_manifest is None:
+            fallback_used = True
+            fallback_rationale.append(
+                "configured routing model "
+                f"{configured_mode_model!r} for mode {payload.mode!r} is not installed; "
+                "using auto-selection fallback",
+            )
+        else:
+            configured_request = _auto_payload_to_forecast_payload(
+                payload=payload,
+                model=configured_mode_model,
+                default_timeout=AUTO_FORECAST_MEMBER_TIMEOUT_SECONDS,
+            )
+            try:
+                configured_response = _execute_forecast(
+                    app,
+                    payload=configured_request,
+                    request=request,
+                )
+            except HTTPException as exc:
+                fallback_used = True
+                blocked_models.add(configured_mode_model)
+                fallback_rationale.append(
+                    "configured routing model "
+                    f"{configured_mode_model!r} for mode {payload.mode!r} failed "
+                    f"({exc.status_code}): {_compare_error_message(exc)}; "
+                    "using auto-selection fallback",
+                )
+            else:
+                return AutoForecastResponse(
+                    strategy=payload.strategy,
+                    selection=_manual_auto_selection_info(
+                        payload=payload,
+                        model=configured_mode_model,
+                        manifest=configured_manifest,
+                        rationale_message=(
+                            "configured routing model "
+                            f"{configured_mode_model!r} selected for mode {payload.mode!r}"
+                        ),
+                    ),
+                    response=configured_response,
+                )
 
     if payload.model is not None:
         explicit_model = payload.model
@@ -2531,6 +2591,7 @@ def _manual_auto_selection_info(
     payload: AutoForecastRequest,
     model: str,
     manifest: dict[str, Any],
+    rationale_message: str = "explicit model override applied",
 ) -> AutoSelectionInfo:
     family = _manifest_family_or_500(manifest, model)
     return AutoSelectionInfo(
@@ -2543,10 +2604,10 @@ def _manual_auto_selection_info(
                 family=family,
                 rank=1,
                 score=0.0,
-                reasons=["explicit model override applied"],
+                reasons=[rationale_message],
             )
         ],
-        rationale=["explicit model override applied"],
+        rationale=[rationale_message],
         fallback_used=False,
     )
 

--- a/tests/test_auto_forecast.py
+++ b/tests/test_auto_forecast.py
@@ -95,6 +95,106 @@ def test_daemon_auto_forecast_falls_back_for_missing_explicit_model(monkeypatch,
     assert body["response"]["model"] == "mock"
 
 
+def test_daemon_auto_forecast_mode_uses_configured_routing_default(monkeypatch, tmp_path) -> None:
+    paths = TollamaPaths(base_dir=tmp_path / ".tollama")
+    monkeypatch.setenv("TOLLAMA_HOME", str(paths.base_dir))
+    install_from_registry("mock", accept_license=True, paths=paths)
+
+    paths.config_path.parent.mkdir(parents=True, exist_ok=True)
+    paths.config_path.write_text(
+        (
+            "{"
+            '"version":1,'
+            '"pull":{},'
+            '"daemon":{},'
+            '"auth":{},'
+            '"routing":{"default":"mock","fast_path":"mock","high_accuracy":"mock"}'
+            "}"
+        ),
+        encoding="utf-8",
+    )
+
+    payload = _auto_payload()
+    payload["mode"] = "fast_path"
+
+    with TestClient(create_app()) as client:
+        response = client.post("/api/auto-forecast", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["selection"]["chosen_model"] == "mock"
+    assert body["selection"]["fallback_used"] is False
+    assert "configured routing model" in body["selection"]["rationale"][0]
+
+
+def test_daemon_auto_forecast_mode_falls_back_when_configured_model_not_installed(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    paths = TollamaPaths(base_dir=tmp_path / ".tollama")
+    monkeypatch.setenv("TOLLAMA_HOME", str(paths.base_dir))
+    install_from_registry("mock", accept_license=True, paths=paths)
+
+    paths.config_path.parent.mkdir(parents=True, exist_ok=True)
+    paths.config_path.write_text(
+        (
+            "{"
+            '"version":1,'
+            '"pull":{},'
+            '"daemon":{},'
+            '"auth":{},'
+            '"routing":{"default":"chronos2","fast_path":"chronos2","high_accuracy":"chronos2"}'
+            "}"
+        ),
+        encoding="utf-8",
+    )
+
+    payload = _auto_payload()
+    payload["mode"] = "high_accuracy"
+
+    with TestClient(create_app()) as client:
+        response = client.post("/api/auto-forecast", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["selection"]["fallback_used"] is True
+    assert body["selection"]["chosen_model"] == "mock"
+    assert any("not installed" in item for item in body["selection"]["rationale"])
+
+
+def test_daemon_auto_forecast_explicit_model_overrides_mode_default(monkeypatch, tmp_path) -> None:
+    paths = TollamaPaths(base_dir=tmp_path / ".tollama")
+    monkeypatch.setenv("TOLLAMA_HOME", str(paths.base_dir))
+    install_from_registry("mock", accept_license=True, paths=paths)
+    install_from_registry("chronos2", accept_license=True, paths=paths)
+
+    paths.config_path.parent.mkdir(parents=True, exist_ok=True)
+    paths.config_path.write_text(
+        (
+            "{"
+            '"version":1,'
+            '"pull":{},'
+            '"daemon":{},'
+            '"auth":{},'
+            '"routing":{"default":"chronos2","fast_path":"chronos2","high_accuracy":"chronos2"}'
+            "}"
+        ),
+        encoding="utf-8",
+    )
+
+    payload = _auto_payload()
+    payload["model"] = "mock"
+    payload["mode"] = "fast_path"
+
+    with TestClient(create_app()) as client:
+        response = client.post("/api/auto-forecast", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["selection"]["chosen_model"] == "mock"
+    assert body["response"]["model"] == "mock"
+
+
 def test_daemon_auto_forecast_falls_back_when_explicit_model_runner_fails(
     monkeypatch,
     tmp_path,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -150,3 +150,26 @@ def test_auth_api_keys_round_trip(monkeypatch, tmp_path) -> None:
 
     reloaded = load_config(paths)
     assert reloaded.auth.api_keys == ["key-1", "key-2"]
+
+
+def test_routing_defaults_round_trip(monkeypatch, tmp_path) -> None:
+    paths = _paths_from_env(monkeypatch, tmp_path)
+    updated = update_config(
+        paths,
+        {
+            "routing": {
+                "default": "lag-llama",
+                "fast_path": "nhits",
+                "high_accuracy": "nbeatsx",
+            }
+        },
+    )
+
+    assert updated.routing.default == "lag-llama"
+    assert updated.routing.fast_path == "nhits"
+    assert updated.routing.high_accuracy == "nbeatsx"
+
+    reloaded = load_config(paths)
+    assert reloaded.routing.default == "lag-llama"
+    assert reloaded.routing.fast_path == "nhits"
+    assert reloaded.routing.high_accuracy == "nbeatsx"


### PR DESCRIPTION
## Summary
- add persistent config routing defaults (`routing.default`, `routing.fast_path`, `routing.high_accuracy`)
- add `mode` (`default`/`fast_path`/`high_accuracy`) to auto-forecast request payload
- wire daemon auto-forecast flow to honor configured routing model by mode when `model` is omitted
- keep explicit model requests authoritative; routing defaults only apply when no explicit model is provided
- add fallback behavior when configured routing model is unavailable/fails, then continue normal auto-selection
- add tests for routing selection and fallback behavior
- document config + usage examples in README and `docs/tsfm-routing-defaults.md`

## Testing
- `pytest -q tests/test_config.py tests/test_auto_forecast.py tests/test_cli_config.py tests/test_schemas.py`
