### PR TITLE
feat(benchmark): add failure classification for routing calibration

### DIFF
--- a/benchmarks/cross_model_tsfm.py
+++ b/benchmarks/cross_model_tsfm.py
@@ -47,6 +47,7 @@ class ModelRun:
     dataset: str
     status: str
     error: str | None
+    error_classification: str | None
     quality: dict[str, float]
     latency_ms: dict[str, float]
 
@@ -237,6 +238,17 @@ def _recommend_routing(runs: list[ModelRun]) -> dict[str, Any]:
     }
 
 
+def _classify_run_error(error: str) -> str:
+    text = error.lower()
+    if "dependency_missing" in text:
+        return "DEPENDENCY_GATED"
+    if "no module named" in text or "not installed" in text:
+        return "DEPENDENCY_GATED"
+    if "runner family" in text and "is not supported" in text:
+        return "UNSUPPORTED_FAMILY_REGRESSION"
+    return "EXECUTION_ERROR"
+
+
 def _run_single(
     *,
     client: TollamaClient,
@@ -291,15 +303,18 @@ def _run_single(
             dataset=series.dataset,
             status="pass",
             error=None,
+            error_classification=None,
             quality=quality,
             latency_ms=latency,
         )
     except Exception as exc:  # noqa: BLE001
+        error = str(exc)
         return ModelRun(
             model=model,
             dataset=series.dataset,
             status="fail",
-            error=str(exc),
+            error=error,
+            error_classification=_classify_run_error(error),
             quality={},
             latency_ms={},
         )
@@ -335,14 +350,15 @@ def _markdown_report(payload: dict[str, Any]) -> str:
         "",
         "## Per-run results",
         "",
-        "| model | dataset | status | sMAPE | MASE | p50 latency (ms) | p95 latency (ms) | error |",
-        "|---|---|---|---:|---:|---:|---:|---|",
+        "| model | dataset | status | error class | sMAPE | MASE | "
+        "p50 latency (ms) | p95 latency (ms) | error |",
+        "|---|---|---|---|---:|---:|---:|---:|---|",
     ]
     for row in payload["runs"]:
         q = row.get("quality", {})
         latency = row.get("latency_ms", {})
         row_template = (
-            "| {model} | {dataset} | {status} | {smape} | {mase} | "
+            "| {model} | {dataset} | {status} | {error_class} | {smape} | {mase} | "
             "{p50} | {p95} | {error} |"
         )
         lines.append(
@@ -350,6 +366,7 @@ def _markdown_report(payload: dict[str, Any]) -> str:
                 model=row["model"],
                 dataset=row["dataset"],
                 status=row["status"],
+                error_class=row.get("error_classification") or "-",
                 smape=q.get("smape", "-"),
                 mase=q.get("mase", "-"),
                 p50=latency.get("p50", "-"),
@@ -357,6 +374,18 @@ def _markdown_report(payload: dict[str, Any]) -> str:
                 error=(row.get("error") or "").replace("|", "/"),
             )
         )
+
+    failure_counts: dict[str, int] = {}
+    for row in payload["runs"]:
+        if row.get("status") != "fail":
+            continue
+        key = str(row.get("error_classification") or "EXECUTION_ERROR")
+        failure_counts[key] = failure_counts.get(key, 0) + 1
+
+    if failure_counts:
+        lines.extend(["", "## Failure classification summary", ""])
+        for key, value in sorted(failure_counts.items()):
+            lines.append(f"- {key}: {value}")
 
     routing = payload["routing_recommendation"]
     lines.extend(
@@ -404,8 +433,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.template_only:
         template_payload = {
-            "run_id": run_id,
-            "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+            "run_id": "<template-run-id>",
+            "generated_at": "<template-generated-at>",
             "protocol": protocol,
             "runs": [],
             "routing_recommendation": {
@@ -474,6 +503,7 @@ def main(argv: list[str] | None = None) -> int:
                 "dataset": run.dataset,
                 "status": run.status,
                 "error": run.error,
+                "error_classification": run.error_classification,
                 "quality": run.quality,
                 "latency_ms": run.latency_ms,
             }

--- a/benchmarks/reports/cross_model_baseline/report_template.json
+++ b/benchmarks/reports/cross_model_baseline/report_template.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-06T14:10:42+00:00",
+  "generated_at": "<template-generated-at>",
   "protocol": {
     "base_url": "http://127.0.0.1:11435",
     "context_length": 96,
@@ -39,6 +39,6 @@
     "high_accuracy": "<to-be-filled>",
     "policy": "Populate after benchmark execution."
   },
-  "run_id": "20260306T141042Z",
+  "run_id": "<template-run-id>",
   "runs": []
 }

--- a/benchmarks/reports/cross_model_baseline/report_template.md
+++ b/benchmarks/reports/cross_model_baseline/report_template.md
@@ -1,7 +1,7 @@
 # Cross-Model TSFM Benchmark Report
 
-- run_id: `20260306T141042Z`
-- generated_at: `2026-03-06T14:10:42+00:00`
+- run_id: `<template-run-id>`
+- generated_at: `<template-generated-at>`
 - base_url: `http://127.0.0.1:11435`
 - models: lag-llama, patchtst, tide, nhits, nbeatsx
 - datasets: seasonal_daily, trend_weekly, intermittent_daily
@@ -10,8 +10,8 @@
 
 ## Per-run results
 
-| model | dataset | status | sMAPE | MASE | p50 latency (ms) | p95 latency (ms) | error |
-|---|---|---|---:|---:|---:|---:|---|
+| model | dataset | status | error class | sMAPE | MASE | p50 latency (ms) | p95 latency (ms) | error |
+|---|---|---|---|---:|---:|---:|---:|---|
 
 ## Routing recommendation
 

--- a/docs/tsfm-routing-defaults.md
+++ b/docs/tsfm-routing-defaults.md
@@ -98,6 +98,10 @@ configured routing defaults.
 - First-run latency can be inflated by model/runtime bootstrap and cache misses.
 - If model dependencies are missing, use template artifacts and mark recommendation
   as provisional.
+- In real benchmark output, interpret failure classes as:
+  - `DEPENDENCY_GATED`: expected environment/dependency limitation
+  - `UNSUPPORTED_FAMILY_REGRESSION`: implementation regression requiring code fix
+  - `EXECUTION_ERROR`: other runtime/transport failures to triage
 
 ## Baseline artifact in repository
 

--- a/src/tollama/runners/lag_llama_runner/main.py
+++ b/src/tollama/runners/lag_llama_runner/main.py
@@ -149,7 +149,10 @@ def _handle_forecast(request: ProtocolRequest, adapter: LagLlamaAdapter) -> Prot
         runner_name=RUNNER_NAME,
         inference_ms=inference_ms,
     )
-    return ProtocolResponse(id=request.id, result=response.model_dump(mode="json", exclude_none=True))
+    return ProtocolResponse(
+        id=request.id,
+        result=response.model_dump(mode="json", exclude_none=True),
+    )
 
 
 def handle_request_line(line: str | bytes, adapter: LagLlamaAdapter) -> ProtocolResponse:


### PR DESCRIPTION
## Summary
- add benchmark run failure classification (`DEPENDENCY_GATED`, `UNSUPPORTED_FAMILY_REGRESSION`, `EXECUTION_ERROR`)
- include error class in benchmark markdown/json report rows and add failure-class summary section
- make template artifact deterministic with placeholder `run_id`/`generated_at` values
- document the classification policy in `docs/tsfm-routing-defaults.md`
- re-wrap a long line in `lag_llama_runner/main.py` to keep Ruff green on main-derived branch

## Why
Issue #49 asks for reproducible benchmark artifacts and clear triage between dependency-gated outcomes and true regressions when calibrating routing defaults.

## Validation
- `ruff check .`
- `pytest -q tests/test_auto_forecast.py tests/test_config.py`

Closes #49
