### PR TITLE
fix(ci): harden readiness probe and runner error contract triage

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -297,6 +297,29 @@ Notes:
 - Prefer `runtime update`/`install --reinstall` over manual venv deletion.
 - If rebuild keeps failing, capture stderr logs and run `tollama doctor` before opening an issue.
 
+## 15) CI triage: dependency-gated vs regression failures
+
+Symptoms:
+- Real-data/runner checks fail in CI, but failures look environment-sensitive.
+- You need to decide whether to block merge or classify as expected gating.
+
+Classification guide:
+- `DEPENDENCY_MISSING` → treat as **dependency-gated** (expected when optional deps are absent).
+- `runner family '<family>' is not supported` → treat as **regression** (must be fixed before merge).
+- Daemon readiness should probe `/v1/health` first, with `/api/health` only as compatibility fallback.
+
+Quick checks:
+```bash
+# Health probe contract
+curl -sf http://127.0.0.1:11435/v1/health >/dev/null || curl -sf http://127.0.0.1:11435/api/health >/dev/null
+
+# Find dependency-gated outcomes in logs
+grep -R "DEPENDENCY_MISSING" artifacts/ -n || true
+
+# Find unsupported-family regressions in logs
+grep -R "runner family .* is not supported" artifacts/ -n || true
+```
+
 ---
 
 ## Quick Triage Commands

--- a/scripts/e2e_skills_test.sh
+++ b/scripts/e2e_skills_test.sh
@@ -55,13 +55,16 @@ echo "Daemon PID: $DAEMON_PID"
 echo "Waiting for daemon to be ready on port $DAEMON_PORT..."
 MAX_RETRIES=30
 for ((i=1; i<=MAX_RETRIES; i++)); do
-    if curl -s "http://$DAEMON_HOST:$DAEMON_PORT/v1/health" >/dev/null || \
-       curl -s "http://$DAEMON_HOST:$DAEMON_PORT/api/health" >/dev/null; then
-        echo -e "${GREEN}Daemon is ready!${NC}"
+    if curl -sf "http://$DAEMON_HOST:$DAEMON_PORT/v1/health" >/dev/null; then
+        echo -e "${GREEN}Daemon is ready via /v1/health.${NC}"
+        break
+    fi
+    if curl -sf "http://$DAEMON_HOST:$DAEMON_PORT/api/health" >/dev/null; then
+        echo -e "${GREEN}Daemon is ready via /api/health fallback.${NC}"
         break
     fi
     if [[ $i -eq $MAX_RETRIES ]]; then
-        echo -e "${RED}Timeout waiting for daemon.${NC}"
+        echo -e "${RED}Timeout waiting for daemon readiness on /v1/health (fallback /api/health).${NC}"
         exit 1
     fi
     sleep 1

--- a/src/tollama/runners/lag_llama_runner/main.py
+++ b/src/tollama/runners/lag_llama_runner/main.py
@@ -149,7 +149,10 @@ def _handle_forecast(request: ProtocolRequest, adapter: LagLlamaAdapter) -> Prot
         runner_name=RUNNER_NAME,
         inference_ms=inference_ms,
     )
-    return ProtocolResponse(id=request.id, result=response.model_dump(mode="json", exclude_none=True))
+    return ProtocolResponse(
+        id=request.id,
+        result=response.model_dump(mode="json", exclude_none=True),
+    )
 
 
 def handle_request_line(line: str | bytes, adapter: LagLlamaAdapter) -> ProtocolResponse:

--- a/tests/test_runner_manager.py
+++ b/tests/test_runner_manager.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import sys
 
+import pytest
 from fastapi.testclient import TestClient
 
 from tollama.core.storage import TollamaPaths, install_from_registry
 from tollama.daemon.app import create_app
 from tollama.daemon.runner_manager import RunnerManager
+from tollama.daemon.supervisor import RunnerUnavailableError
 
 
 def _chronos_payload() -> dict[str, object]:
@@ -165,6 +167,21 @@ def _nhits_payload() -> dict[str, object]:
         ],
         "options": {},
     }
+
+
+def test_runner_manager_reports_unsupported_family_with_stable_error_message() -> None:
+    manager = RunnerManager(runner_commands={})
+
+    with pytest.raises(
+        RunnerUnavailableError,
+        match="runner family 'unknown-family' is not supported",
+    ):
+        manager.call(
+            family="unknown-family",
+            method="forecast",
+            params={},
+            timeout=1.0,
+        )
 
 
 def test_daemon_routes_torch_family_to_torch_runner_command_override(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- harden `scripts/e2e_skills_test.sh` readiness logic to require successful status (`curl -sf`) on `/v1/health` first, then `/api/health` fallback
- improve timeout diagnostics to explicitly mention both health probe endpoints
- add a runner-manager contract test asserting stable unsupported-family message:
  - `runner family 'unknown-family' is not supported`
- add CI triage guidance to `docs/troubleshooting.md` for:
  - `DEPENDENCY_MISSING` => dependency-gated
  - `runner family '<family>' is not supported` => regression
- wrap lingering long line in `lag_llama_runner/main.py` so Ruff remains green

## Validation
- `ruff check tests/test_runner_manager.py src/tollama/runners/lag_llama_runner/main.py`
- `pytest -q tests/test_runner_manager.py::test_runner_manager_reports_unsupported_family_with_stable_error_message`
- `bash -n scripts/e2e_skills_test.sh`

Closes #50
