### PR TITLE
docs(release): capture v0.2.1 post-release quality pass

### DIFF
--- a/docs/releases/v0.2.1-readiness.md
+++ b/docs/releases/v0.2.1-readiness.md
@@ -1,0 +1,50 @@
+# v0.2.1 Readiness Check
+
+Date: 2026-03-07
+
+## Scope
+Post-release quality pass focused on key TSFM runners and auto-forecast behavior:
+
+- lag-llama
+- patchtst
+- nhits
+- nbeatsx
+- tide
+- auto-forecast routing behavior
+
+## Executed checks
+
+### 1) Targeted runner + routing pytest sweep
+
+```bash
+pytest -q \
+  tests/test_lag_llama_runner.py \
+  tests/test_patchtst_runner.py \
+  tests/test_nhits_runner.py \
+  tests/test_nbeatsx_runner.py \
+  tests/test_tide_runner.py \
+  tests/test_auto_forecast.py
+```
+
+Result: **PASS** (`35 passed`)
+
+### 2) Lag-Llama / PatchTST regression script
+
+```bash
+bash scripts/e2e_lag_llama_patchtst_check.sh
+```
+
+Result: **PASS**
+
+- `[1/2]` targeted regression tests passed
+- `[2/2]` success-path smoke intentionally skipped by default (requires `--with-success`)
+
+## Findings
+
+- No runner regressions observed in the targeted post-release sweep.
+- Auto-forecast coverage in `tests/test_auto_forecast.py` passed in this run.
+
+## Follow-up
+
+- Optional: run `scripts/e2e_lag_llama_patchtst_check.sh --with-success` in an environment with model weights preloaded for additional runtime-path confidence.
+- Continue weekly quality-pass cadence alongside benchmark/routing recalibration work.


### PR DESCRIPTION
## Summary
- execute targeted post-release quality checks for key TSFM runners and auto-forecast behavior
- record reproducible commands + outcomes in `docs/releases/v0.2.1-readiness.md`
- capture explicit follow-up for optional success-path smoke in model-preloaded environment

## Checks executed
- `pytest -q tests/test_lag_llama_runner.py tests/test_patchtst_runner.py tests/test_nhits_runner.py tests/test_nbeatsx_runner.py tests/test_tide_runner.py tests/test_auto_forecast.py` (pass)
- `bash scripts/e2e_lag_llama_patchtst_check.sh` (pass; default mode skips success-path smoke)

Closes #51
