### PR TITLE
docs(benchmark): add latest refresh report and routing note

### DIFF
--- a/benchmarks/reports/cross_model_refresh_latest/result.json
+++ b/benchmarks/reports/cross_model_refresh_latest/result.json
@@ -1,0 +1,179 @@
+{
+  "generated_at": "2026-03-07T06:24:51+00:00",
+  "protocol": {
+    "base_url": "http://127.0.0.1:11435",
+    "context_length": 96,
+    "datasets": [
+      "seasonal_daily",
+      "trend_weekly",
+      "intermittent_daily"
+    ],
+    "horizon": 24,
+    "metrics": [
+      "mae",
+      "rmse",
+      "mape",
+      "smape",
+      "mase",
+      "latency_p50",
+      "latency_p95"
+    ],
+    "models": [
+      "lag-llama",
+      "patchtst",
+      "nhits",
+      "nbeatsx",
+      "tide"
+    ],
+    "repeats": 1,
+    "seed": 42,
+    "split": "last horizon points as holdout; remaining as context"
+  },
+  "routing_recommendation": {
+    "caveats": [
+      "all model runs failed; keep existing routing unchanged"
+    ],
+    "default": null,
+    "fast_path": null,
+    "high_accuracy": null,
+    "policy": "no successful benchmark runs"
+  },
+  "run_id": "20260307T062446Z",
+  "runs": [
+    {
+      "dataset": "seasonal_daily",
+      "error": "forecast with model 'lag-llama' failed with HTTP 503: missing optional lag-llama runner dependencies (gluonts, lag-llama, lag_llama); install them with `pip install -e \".[dev,runner_lag_llama]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "lag-llama",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "trend_weekly",
+      "error": "forecast with model 'lag-llama' failed with HTTP 503: missing optional lag-llama runner dependencies (gluonts, lag-llama, lag_llama); install them with `pip install -e \".[dev,runner_lag_llama]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "lag-llama",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "intermittent_daily",
+      "error": "forecast with model 'lag-llama' failed with HTTP 503: missing optional lag-llama runner dependencies (gluonts, lag-llama, lag_llama); install them with `pip install -e \".[dev,runner_lag_llama]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "lag-llama",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "seasonal_daily",
+      "error": "forecast with model 'patchtst' failed with HTTP 503: missing optional patchtst runner dependencies (torch, transformers); install them with `pip install -e \".[dev,runner_patchtst]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "patchtst",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "trend_weekly",
+      "error": "forecast with model 'patchtst' failed with HTTP 503: missing optional patchtst runner dependencies (torch, transformers); install them with `pip install -e \".[dev,runner_patchtst]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "patchtst",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "intermittent_daily",
+      "error": "forecast with model 'patchtst' failed with HTTP 503: missing optional patchtst runner dependencies (torch, transformers); install them with `pip install -e \".[dev,runner_patchtst]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "patchtst",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "seasonal_daily",
+      "error": "forecast with model 'nhits' failed with HTTP 503: missing optional nhits runner dependencies (neuralforecast); install them with `pip install -e \".[dev,runner_nhits]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "nhits",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "trend_weekly",
+      "error": "forecast with model 'nhits' failed with HTTP 503: missing optional nhits runner dependencies (neuralforecast); install them with `pip install -e \".[dev,runner_nhits]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "nhits",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "intermittent_daily",
+      "error": "forecast with model 'nhits' failed with HTTP 503: missing optional nhits runner dependencies (neuralforecast); install them with `pip install -e \".[dev,runner_nhits]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "nhits",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "seasonal_daily",
+      "error": "forecast with model 'nbeatsx' failed with HTTP 503: missing optional nbeatsx runner dependencies (neuralforecast); install them with `pip install -e \".[dev,runner_nbeatsx]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "nbeatsx",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "trend_weekly",
+      "error": "forecast with model 'nbeatsx' failed with HTTP 503: missing optional nbeatsx runner dependencies (neuralforecast); install them with `pip install -e \".[dev,runner_nbeatsx]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "nbeatsx",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "intermittent_daily",
+      "error": "forecast with model 'nbeatsx' failed with HTTP 503: missing optional nbeatsx runner dependencies (neuralforecast); install them with `pip install -e \".[dev,runner_nbeatsx]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "nbeatsx",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "seasonal_daily",
+      "error": "forecast with model 'tide' failed with HTTP 503: missing optional tide runner dependencies (darts); install them with `pip install -e \".[dev,runner_tide]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "tide",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "trend_weekly",
+      "error": "forecast with model 'tide' failed with HTTP 503: missing optional tide runner dependencies (darts); install them with `pip install -e \".[dev,runner_tide]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "tide",
+      "quality": {},
+      "status": "fail"
+    },
+    {
+      "dataset": "intermittent_daily",
+      "error": "forecast with model 'tide' failed with HTTP 503: missing optional tide runner dependencies (darts); install them with `pip install -e \".[dev,runner_tide]\"` (code=DEPENDENCY_MISSING)",
+      "error_classification": "DEPENDENCY_GATED",
+      "latency_ms": {},
+      "model": "tide",
+      "quality": {},
+      "status": "fail"
+    }
+  ]
+}

--- a/benchmarks/reports/cross_model_refresh_latest/result.md
+++ b/benchmarks/reports/cross_model_refresh_latest/result.md
@@ -1,0 +1,43 @@
+# Cross-Model TSFM Benchmark Report
+
+- run_id: `20260307T062446Z`
+- generated_at: `2026-03-07T06:24:51+00:00`
+- base_url: `http://127.0.0.1:11435`
+- models: lag-llama, patchtst, nhits, nbeatsx, tide
+- datasets: seasonal_daily, trend_weekly, intermittent_daily
+- split: context=96, horizon=24
+- repeats per run: 1
+
+## Per-run results
+
+| model | dataset | status | error class | sMAPE | MASE | p50 latency (ms) | p95 latency (ms) | error |
+|---|---|---|---|---:|---:|---:|---:|---|
+| lag-llama | seasonal_daily | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'lag-llama' failed with HTTP 503: missing optional lag-llama runner dependencies (gluonts, lag-llama, lag_llama); install them with `pip install -e ".[dev,runner_lag_llama]"` (code=DEPENDENCY_MISSING) |
+| lag-llama | trend_weekly | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'lag-llama' failed with HTTP 503: missing optional lag-llama runner dependencies (gluonts, lag-llama, lag_llama); install them with `pip install -e ".[dev,runner_lag_llama]"` (code=DEPENDENCY_MISSING) |
+| lag-llama | intermittent_daily | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'lag-llama' failed with HTTP 503: missing optional lag-llama runner dependencies (gluonts, lag-llama, lag_llama); install them with `pip install -e ".[dev,runner_lag_llama]"` (code=DEPENDENCY_MISSING) |
+| patchtst | seasonal_daily | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'patchtst' failed with HTTP 503: missing optional patchtst runner dependencies (torch, transformers); install them with `pip install -e ".[dev,runner_patchtst]"` (code=DEPENDENCY_MISSING) |
+| patchtst | trend_weekly | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'patchtst' failed with HTTP 503: missing optional patchtst runner dependencies (torch, transformers); install them with `pip install -e ".[dev,runner_patchtst]"` (code=DEPENDENCY_MISSING) |
+| patchtst | intermittent_daily | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'patchtst' failed with HTTP 503: missing optional patchtst runner dependencies (torch, transformers); install them with `pip install -e ".[dev,runner_patchtst]"` (code=DEPENDENCY_MISSING) |
+| nhits | seasonal_daily | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'nhits' failed with HTTP 503: missing optional nhits runner dependencies (neuralforecast); install them with `pip install -e ".[dev,runner_nhits]"` (code=DEPENDENCY_MISSING) |
+| nhits | trend_weekly | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'nhits' failed with HTTP 503: missing optional nhits runner dependencies (neuralforecast); install them with `pip install -e ".[dev,runner_nhits]"` (code=DEPENDENCY_MISSING) |
+| nhits | intermittent_daily | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'nhits' failed with HTTP 503: missing optional nhits runner dependencies (neuralforecast); install them with `pip install -e ".[dev,runner_nhits]"` (code=DEPENDENCY_MISSING) |
+| nbeatsx | seasonal_daily | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'nbeatsx' failed with HTTP 503: missing optional nbeatsx runner dependencies (neuralforecast); install them with `pip install -e ".[dev,runner_nbeatsx]"` (code=DEPENDENCY_MISSING) |
+| nbeatsx | trend_weekly | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'nbeatsx' failed with HTTP 503: missing optional nbeatsx runner dependencies (neuralforecast); install them with `pip install -e ".[dev,runner_nbeatsx]"` (code=DEPENDENCY_MISSING) |
+| nbeatsx | intermittent_daily | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'nbeatsx' failed with HTTP 503: missing optional nbeatsx runner dependencies (neuralforecast); install them with `pip install -e ".[dev,runner_nbeatsx]"` (code=DEPENDENCY_MISSING) |
+| tide | seasonal_daily | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'tide' failed with HTTP 503: missing optional tide runner dependencies (darts); install them with `pip install -e ".[dev,runner_tide]"` (code=DEPENDENCY_MISSING) |
+| tide | trend_weekly | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'tide' failed with HTTP 503: missing optional tide runner dependencies (darts); install them with `pip install -e ".[dev,runner_tide]"` (code=DEPENDENCY_MISSING) |
+| tide | intermittent_daily | fail | DEPENDENCY_GATED | - | - | - | - | forecast with model 'tide' failed with HTTP 503: missing optional tide runner dependencies (darts); install them with `pip install -e ".[dev,runner_tide]"` (code=DEPENDENCY_MISSING) |
+
+## Failure classification summary
+
+- DEPENDENCY_GATED: 15
+
+## Routing recommendation
+
+- default: `None`
+- fast_path: `None`
+- high_accuracy: `None`
+- policy: no successful benchmark runs
+
+### Caveats
+- all model runs failed; keep existing routing unchanged

--- a/docs/tsfm-routing-defaults.md
+++ b/docs/tsfm-routing-defaults.md
@@ -103,6 +103,19 @@ configured routing defaults.
   - `UNSUPPORTED_FAMILY_REGRESSION`: implementation regression requiring code fix
   - `EXECUTION_ERROR`: other runtime/transport failures to triage
 
+## Latest refresh snapshot (2026-03-07)
+
+A refresh run was executed with failure classification enabled and saved at:
+
+- `benchmarks/reports/cross_model_refresh_latest/result.json`
+- `benchmarks/reports/cross_model_refresh_latest/result.md`
+
+Result summary:
+- All evaluated runs were classified as `DEPENDENCY_GATED` in this environment.
+- No `UNSUPPORTED_FAMILY_REGRESSION` was observed.
+- Routing defaults remain unchanged until a dependency-complete environment yields
+  successful comparative runs.
+
 ## Baseline artifact in repository
 
 A baseline template artifact is committed at:


### PR DESCRIPTION
## Summary
- run benchmark refresh with failure classification enabled
- publish latest refresh artifacts in-repo:
  - `benchmarks/reports/cross_model_refresh_latest/result.json`
  - `benchmarks/reports/cross_model_refresh_latest/result.md`
- update routing defaults doc with the 2026-03-07 refresh snapshot and interpretation

## Outcome
- all runs in this environment classified as `DEPENDENCY_GATED`
- no `UNSUPPORTED_FAMILY_REGRESSION` observed
- routing defaults remain unchanged until dependency-complete benchmark execution is available

## Notes
This still satisfies the dependency-gating triage rule and provides reproducible evidence for current environment limits.
