### PR TITLE
feat(benchmark): normalize calibration inputs and tighten runner deps

### DIFF
--- a/benchmarks/cross_model_tsfm.py
+++ b/benchmarks/cross_model_tsfm.py
@@ -21,7 +21,7 @@ import json
 import math
 import statistics
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from time import perf_counter
 from typing import Any
@@ -249,6 +249,16 @@ def _classify_run_error(error: str) -> str:
     return "EXECUTION_ERROR"
 
 
+def _build_timestamps(*, freq: str, count: int) -> list[str]:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    normalized = freq.strip().upper()
+    if normalized.startswith("W"):
+        step = timedelta(weeks=1)
+    else:
+        step = timedelta(days=1)
+    return [(start + i * step).date().isoformat() for i in range(count)]
+
+
 def _run_single(
     *,
     client: TollamaClient,
@@ -264,7 +274,7 @@ def _run_single(
             {
                 "id": f"{series.dataset}-s1",
                 "freq": series.freq,
-                "timestamps": [str(i + 1) for i in range(len(series.context))],
+                "timestamps": _build_timestamps(freq=series.freq, count=len(series.context)),
                 "target": series.context,
             }
         ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,9 @@ runner_lag_llama = [
   "wandb==0.25.0",
 ]
 runner_patchtst = [
-  "transformers>=4.40.1,<6.0",
+  "numpy>=1.26,<2.0",
+  "torch>=2.2,<2.4",
+  "transformers>=4.40.1,<4.48",
 ]
 runner_tide = [
   "u8darts>=0.30.0",
@@ -135,13 +137,17 @@ runner_tide = [
 ]
 runner_nhits = [
   "neuralforecast>=1.7.0",
+  "numpy>=1.26,<2.0",
   "pytorch-lightning>=2.0,<3.0",
-  "torch>=2.0",
+  "scipy>=1.10,<2.0",
+  "torch>=2.2",
 ]
 runner_nbeatsx = [
   "neuralforecast>=1.7.0",
+  "numpy>=1.26,<2.0",
   "pytorch-lightning>=2.0,<3.0",
-  "torch>=2.0",
+  "scipy>=1.10,<2.0",
+  "torch>=2.2",
 ]
 tui = [
   "textual>=0.47,<9.0",


### PR DESCRIPTION
## Summary
Advance issue #61 with CI-verifiable calibration unblock changes (no local-only toolchain dependency required).

### 1) Benchmark input normalization
- `benchmarks/cross_model_tsfm.py`
- replace synthetic numeric timestamps with deterministic ISO date timestamps
- keeps frequency validation paths realistic for runner adapters

### 2) Runner dependency tightening for reproducible runtime bootstrap
- `pyproject.toml`
- refine extras for calibration-target runners:
  - `runner_patchtst`: add explicit `numpy` and `torch` constraints, and cap `transformers`
  - `runner_nhits` / `runner_nbeatsx`: add explicit `numpy` + `scipy` constraints

## Why
On this host, full success-based calibration is currently gated by environment/runtime constraints. This PR moves forward all code/config improvements that can be validated via CI and improves determinism of the next calibration attempt.

## Validation
- `ruff check benchmarks/cross_model_tsfm.py pyproject.toml`
- `pytest -q tests/test_cross_model_benchmark.py tests/test_runtime_bootstrap.py tests/test_runner_manager.py`

Refs #61
